### PR TITLE
feat: implement language selector in navbar

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -182,3 +182,12 @@ Services follow a defined type structure (see `src/types/service.js`):
 - Each service has: `id`, `title`, `description`, `icon`, `color`, `url`
 - Extended properties: `quickStart`, `useCases`, `category`
 - Mock data is currently in `ServicesApiClient` for development
+
+
+## To following at the end of any implementation
+- Create a pull request with a detailed description of changes e a new branch
+- Branch created for each feature has to following this patter to name
+  - feature/short-description
+  - fix/short-description
+  - chore/short-description
+- Setup a precise descriptions of the changes mades and how to test it.

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -43,6 +43,8 @@
               </a>
             </template>
           </nav>
+          <!-- Language Selector -->
+          <LanguageSelector />
           <!-- Social Links -->
           <div class="flex items-center space-x-4">
             <a href="https://github.com/brenonaraujo" target="_blank" rel="noopener noreferrer">
@@ -97,6 +99,10 @@
                 </a>
               </template>
             </div>
+            <!-- Language Selector for Mobile -->
+            <div class="mt-8 flex justify-center">
+              <LanguageSelector />
+            </div>
           </nav>
         </div>
       </div>
@@ -105,19 +111,22 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import SocialLinks from './SocialLinks.vue'
+import LanguageSelector from './ui/LanguageSelector.vue'
 
 const router = useRouter()
+const { t } = useI18n()
 const isMobileMenuOpen = ref(false)
 
-const menuItems = [
-  { to: 'how-it-works', text: 'How it works' },
-  { to: 'docker', text: 'Services' },
-  { to: 'about', text: 'About' },
-  { to: 'https://uptime.brenon.cloud/status/services', text: 'Status', external: true }
-]
+const menuItems = computed(() => [
+  { to: 'how-it-works', text: t('navbar.howItWorks') },
+  { to: 'docker', text: t('navbar.services') },
+  { to: 'about', text: t('navbar.about') },
+  { to: 'https://uptime.brenon.cloud/status/services', text: t('navbar.status'), external: true }
+])
 
 const scrollToSection = (sectionId) => {
   if (isMobileMenuOpen.value) {

--- a/src/components/ui/LanguageSelector.vue
+++ b/src/components/ui/LanguageSelector.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="relative inline-block text-left" ref="dropdownRef">
+    <button
+      @click="toggleDropdown"
+      type="button"
+      class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800/50 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+      :aria-expanded="isOpen"
+      aria-haspopup="true"
+    >
+      <span class="mr-2">{{ getCurrentLanguageFlag() }}</span>
+      <span>{{ getCurrentLanguageName() }}</span>
+      <svg 
+        class="ml-2 h-4 w-4 transition-transform duration-200" 
+        :class="{ 'rotate-180': isOpen }"
+        fill="none" 
+        viewBox="0 0 24 24" 
+        stroke="currentColor"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+
+    <transition
+      enter-active-class="transition ease-out duration-100"
+      enter-from-class="transform opacity-0 scale-95"
+      enter-to-class="transform opacity-100 scale-100"
+      leave-active-class="transition ease-in duration-75"
+      leave-from-class="transform opacity-100 scale-100"
+      leave-to-class="transform opacity-0 scale-95"
+    >
+      <div
+        v-show="isOpen"
+        class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-gray-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+        role="menu"
+        aria-orientation="vertical"
+      >
+        <div class="py-1" role="none">
+          <button
+            v-for="language in availableLanguages"
+            :key="language.code"
+            @click="selectLanguage(language.code)"
+            class="group flex w-full items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
+            :class="{ 'bg-gray-700 text-white': currentLocale === language.code }"
+            role="menuitem"
+          >
+            <span class="mr-3">{{ language.flag }}</span>
+            <span>{{ language.name }}</span>
+            <svg
+              v-if="currentLocale === language.code"
+              class="ml-auto h-4 w-4 text-blue-400"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { locale } = useI18n()
+
+const isOpen = ref(false)
+const dropdownRef = ref(null)
+
+const availableLanguages = [
+  { code: 'en', name: 'English', flag: '🇺🇸' },
+  { code: 'pt', name: 'Português', flag: '🇧🇷' }
+]
+
+const currentLocale = computed(() => locale.value)
+
+const getCurrentLanguageFlag = () => {
+  const language = availableLanguages.find(lang => lang.code === currentLocale.value)
+  return language?.flag || '🌐'
+}
+
+const getCurrentLanguageName = () => {
+  const language = availableLanguages.find(lang => lang.code === currentLocale.value)
+  return language?.name || 'Language'
+}
+
+const toggleDropdown = () => {
+  isOpen.value = !isOpen.value
+}
+
+const selectLanguage = (languageCode) => {
+  locale.value = languageCode
+  localStorage.setItem('preferred-language', languageCode)
+  isOpen.value = false
+}
+
+// Close dropdown when clicking outside
+const handleClickOutside = (event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    isOpen.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+  
+  // Load saved language preference
+  const savedLanguage = localStorage.getItem('preferred-language')
+  if (savedLanguage && availableLanguages.some(lang => lang.code === savedLanguage)) {
+    locale.value = savedLanguage
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,5 +147,13 @@
     "error": "An error occurred",
     "retry": "Retry",
     "close": "Close"
+  },
+  "navbar": {
+    "language": "Language",
+    "selectLanguage": "Select Language",
+    "howItWorks": "How it works",
+    "services": "Services",
+    "about": "About",
+    "status": "Status"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -147,5 +147,13 @@
     "error": "Ocorreu um erro",
     "retry": "Tentar novamente",
     "close": "Fechar"
+  },
+  "navbar": {
+    "language": "Idioma",
+    "selectLanguage": "Selecionar Idioma",
+    "howItWorks": "Como funciona",
+    "services": "Serviços",
+    "about": "Sobre",
+    "status": "Status"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -44,10 +44,19 @@ const router = createRouter({
 // Pinia store
 const pinia = createPinia()
 
+// Get saved language preference or use browser default
+const getInitialLocale = () => {
+  const savedLanguage = localStorage.getItem('preferred-language')
+  if (savedLanguage && ['en', 'pt'].includes(savedLanguage)) {
+    return savedLanguage
+  }
+  return navigator.language.startsWith('pt') ? 'pt' : 'en'
+}
+
 // i18n configuration
 const i18n = createI18n({
   legacy: false, // Use Composition API
-  locale: navigator.language.startsWith('pt') ? 'pt' : 'en', // Default locale based on browser
+  locale: getInitialLocale(), // Load saved preference or use browser default
   fallbackLocale: 'en',
   messages: {
     en,


### PR DESCRIPTION
- Add LanguageSelector UI component with dropdown functionality
- Integrate language selector in both desktop and mobile navbar
- Add persistent language preference using localStorage
- Internationalize navbar menu items with translation keys
- Support English (🇺🇸) and Portuguese (🇧🇷) languages
- Implement smooth animations and responsive design
- Follow clean architecture principles with proper separation of concerns

Features:
- Flag-based language selection with visual feedback
- Click-outside functionality to close dropdown
- Remembers user language preference across sessions
- Seamless integration with existing i18n setup
- Mobile-responsive design matching navbar theme