### PR TITLE
feat(games): add /games section with Tetris, localStorage rankings, EN/PT

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,15 @@
   NODE_VERSION = "22"
   NPM_FLAGS    = "--legacy-peer-deps"
 
+# /games/* holds the standalone game files (iframes). They must be served
+# as static assets, not handed to the SPA. Everything else falls back to
+# the Vue app so deep links like /games/tetris still resolve to the player.
+[[redirects]]
+  from = "/games/*"
+  to   = "/games/:splat"
+  status = 200
+  force = false
+
 [[redirects]]
   from = "/*"
   to   = "/index.html"

--- a/public/games/README.md
+++ b/public/games/README.md
@@ -1,0 +1,90 @@
+# Browser Games
+
+Small browser games embedded in Brenon.Cloud under `/games`.
+
+## Current catalog
+
+| Slug | Category | Players | Score unit | Size |
+| --- | --- | --- | --- | --- |
+| `tetris` | Puzzle | Single | Points | 760 × 720 |
+
+## How scoring works
+
+Scores are kept **per-game** in `localStorage`, scoped to the current browser:
+
+- `tetris.playerName` — last name the player used
+- `tetris.ranking` — top 10 runs as JSON (`[{name, score, when}]`)
+
+Each game should pick its own key prefix (e.g. `snake.ranking`) so different games don't collide.
+
+## Adding a new game
+
+Three files. That's it.
+
+### 1. Build the game as a standalone HTML file
+
+`public/games/<slug>.html` — single-file, no build step. Vanilla JS, canvas, whatever. The only requirement:
+
+```html
+<script>
+// Detect iframe embedding and adapt layout if needed.
+try {
+  if (window.self !== window.top) {
+    document.body.classList.add('embedded');
+  }
+} catch (err) { /* cross-origin frame, ignore */ }
+</script>
+```
+
+Add a `.embedded` stylesheet rule to collapse padding/sidebars so the game fits the iframe box. See `tetris.html` for a complete example.
+
+### 2. Write the neutral manifest
+
+`src/content/games/<slug>.json` — required, carries the technical config:
+
+```json
+{
+  "title": "Snake",
+  "description": "Eat, grow, don't crash into yourself.",
+  "category": "arcade",
+  "players": "single",
+  "scoreUnit": "points",
+  "iframe": "/games/snake.html",
+  "width": 600,
+  "height": 700
+}
+```
+
+`category` must be one of `puzzle | arcade | action | casual` (controls the card gradient).
+
+### 3. Add per-locale overrides (optional)
+
+`src/content/games/<slug>.pt.json` — only `title` and `description` need translation:
+
+```json
+{
+  "title": "Snake",
+  "description": "Coma, cresça e não bata em você mesmo."
+}
+```
+
+If a locale is missing, the neutral file's strings are shown.
+
+### 4. That's it
+
+Vite picks up the new files via `import.meta.glob` at build time. The Games grid renders automatically.
+
+## i18n keys
+
+See `src/locales/{en,pt}.json` under the `games` namespace:
+
+- `games.title`, `games.subtitle`
+- `games.play`, `games.backToList`
+- `games.categories.{puzzle|arcade|action|casual}`
+- `games.units.{points|lines|ms}`
+- `games.playersSingle`, `games.playersMulti`
+- `games.empty.*`, `games.notFound.*`
+
+## Deploy notes
+
+`netlify.toml` redirects `/games/*` to static files first, then falls back to the SPA. So `/games/snake.html` is served directly by Netlify's edge, while `/games/snake` (without extension) goes through the Vue router to the player page.

--- a/public/games/tetris.html
+++ b/public/games/tetris.html
@@ -1,0 +1,1144 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Tetris</title>
+<style>
+  :root {
+    --bg: #0b0d17;
+    --panel: #141826;
+    --grid: #1c2030;
+    --border: #2a3047;
+    --text: #e6e9f2;
+    --muted: #8087a3;
+    --accent: #6cf;
+    --danger: #ff5577;
+    --glow: 0 0 12px rgba(102, 204, 255, 0.6);
+  }
+
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: radial-gradient(ellipse at top, #1a1f3a 0%, var(--bg) 70%);
+    color: var(--text);
+    font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+    height: 100%;
+    min-height: 100vh;
+    overflow: auto;
+  }
+
+  /* When embedded inside an iframe the viewport IS the iframe, so we
+     collapse the outer padding and let the layout fill it. */
+  body.embedded {
+    overflow: hidden;
+  }
+  body.embedded .game {
+    min-height: 100%;
+    padding: 12px;
+    gap: 16px;
+  }
+  body.embedded .side-panel {
+    width: 150px;
+  }
+  body.embedded .side-panel .panel-box {
+    padding: 10px;
+  }
+  body.embedded .player-name {
+    font-size: 14px;
+  }
+  body.embedded .panel-value {
+    font-size: 20px;
+  }
+  body.embedded .next-canvas,
+  body.embedded .hold-canvas {
+    width: 80px;
+    height: 80px;
+  }
+  body.embedded .next-canvas {
+    height: 240px;
+  }
+
+  .game {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+    padding: 20px;
+    min-height: 100vh;
+    flex-wrap: wrap;
+  }
+
+  /* LEFT PANEL */
+  .side-panel {
+    width: 180px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .panel-box {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px;
+  }
+
+  .panel-title {
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+
+  .panel-value {
+    font-size: 24px;
+    font-weight: bold;
+    color: var(--accent);
+    text-shadow: var(--glow);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .next-canvas, .hold-canvas {
+    background: var(--grid);
+    border-radius: 4px;
+    display: block;
+    margin: 0 auto;
+  }
+
+  /* BOARD */
+  .board-wrap {
+    position: relative;
+    background: var(--panel);
+    border: 2px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: 0 0 40px rgba(0, 0, 0, 0.5), inset 0 0 20px rgba(0, 0, 0, 0.3);
+  }
+
+  #board {
+    display: block;
+    background: var(--grid);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 12px;
+    background: rgba(11, 13, 23, 0.92);
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    border-radius: 4px;
+    z-index: 10;
+  }
+
+  .overlay.active { display: flex; }
+
+  .overlay h1 {
+    font-size: 36px;
+    margin: 0 0 10px;
+    color: var(--accent);
+    text-shadow: var(--glow);
+    letter-spacing: 4px;
+  }
+
+  .overlay p {
+    margin: 4px 0;
+    color: var(--muted);
+  }
+
+  .overlay .key {
+    display: inline-block;
+    background: var(--border);
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin: 0 2px;
+    color: var(--text);
+    font-weight: bold;
+  }
+
+  /* NAME INPUT + BUTTON (in overlay) */
+  .overlay input[type="text"] {
+    background: var(--grid);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 18px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    width: 240px;
+    text-align: center;
+    margin-top: 18px;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .overlay input[type="text"]:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(102, 204, 255, 0.2);
+  }
+
+  .overlay button.primary {
+    background: var(--accent);
+    color: #0b0d17;
+    border: none;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: bold;
+    letter-spacing: 2px;
+    padding: 12px 28px;
+    border-radius: 6px;
+    margin-top: 14px;
+    cursor: pointer;
+    text-transform: uppercase;
+    transition: transform 0.1s, box-shadow 0.15s;
+  }
+  .overlay button.primary:hover { box-shadow: var(--glow); }
+  .overlay button.primary:active { transform: scale(0.97); }
+
+  .overlay .last-player {
+    margin-top: 14px;
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  /* RANKING TABLE (in game-over overlay) */
+  .ranking {
+    margin-top: 16px;
+    width: 280px;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  .ranking th, .ranking td {
+    padding: 6px 8px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .ranking th {
+    color: var(--muted);
+    font-weight: normal;
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 1px;
+  }
+  .ranking td:nth-child(1) { color: var(--muted); width: 24px; }
+  .ranking td:nth-child(2) { color: var(--text); }
+  .ranking td:nth-child(3) { color: var(--accent); text-align: right; font-variant-numeric: tabular-nums; }
+  .ranking tr.you td { background: rgba(102, 204, 255, 0.12); }
+  .ranking tr.you td:nth-child(2) { color: var(--accent); font-weight: bold; }
+
+  /* PLAYER PANEL (live during game) */
+  .player-name {
+    font-size: 16px;
+    font-weight: bold;
+    color: var(--text);
+    letter-spacing: 1px;
+  }
+
+  /* CONTROLS PANEL */
+  .controls-panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px;
+    font-size: 12px;
+  }
+
+  .controls-panel h3 {
+    margin: 0 0 10px;
+    color: var(--accent);
+    font-size: 12px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+  }
+
+  .ctrl-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+    color: var(--muted);
+  }
+
+  .ctrl-row span:last-child {
+    color: var(--text);
+    font-weight: bold;
+  }
+
+  /* MOBILE */
+  .mobile-controls {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 12px;
+    background: rgba(11, 13, 23, 0.95);
+    border-top: 1px solid var(--border);
+    z-index: 20;
+  }
+
+  .mobile-row {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .mobile-btn {
+    flex: 1;
+    max-width: 80px;
+    padding: 16px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: bold;
+    touch-action: manipulation;
+    user-select: none;
+  }
+
+  .mobile-btn:active {
+    background: var(--border);
+    transform: scale(0.95);
+  }
+
+  @media (max-width: 720px) {
+    .side-panel { width: 100%; flex-direction: row; flex-wrap: wrap; }
+    .panel-box, .controls-panel { flex: 1; min-width: 120px; }
+    .mobile-controls { display: block; }
+    body { overflow-y: auto; padding-bottom: 200px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="game">
+  <!-- LEFT: PLAYER + HOLD + SCORE -->
+  <div class="side-panel">
+    <div class="panel-box">
+      <div class="panel-title">Player</div>
+      <div class="player-name" id="player-name">—</div>
+    </div>
+    <div class="panel-box">
+      <div class="panel-title">Hold</div>
+      <canvas id="hold" class="hold-canvas" width="100" height="100"></canvas>
+    </div>
+    <div class="panel-box">
+      <div class="panel-title">Score</div>
+      <div class="panel-value" id="score">0</div>
+    </div>
+    <div class="panel-box">
+      <div class="panel-title">Lines</div>
+      <div class="panel-value" id="lines">0</div>
+    </div>
+    <div class="panel-box">
+      <div class="panel-title">Level</div>
+      <div class="panel-value" id="level">1</div>
+    </div>
+  </div>
+
+  <!-- CENTER: BOARD -->
+  <div class="board-wrap">
+    <canvas id="board" width="300" height="600"></canvas>
+    <div id="overlay" class="overlay active">
+      <!-- START MODE -->
+      <div id="overlay-start">
+        <h1 id="overlay-title">TETRIS</h1>
+        <p>Digite seu nome para começar</p>
+        <input type="text" id="player-input" maxlength="12" placeholder="Seu nome" autocomplete="off" spellcheck="false">
+        <br>
+        <button class="primary" id="play-btn">Jogar</button>
+        <p class="last-player" id="last-player"></p>
+        <p style="margin-top: 20px; font-size: 11px;">Setas para mover · <span class="key">↑</span> girar · <span class="key">↓</span> descer · <span class="key">Espaço</span> hard drop · <span class="key">C</span> hold · <span class="key">P</span> pausa</p>
+      </div>
+      <!-- GAME OVER MODE (filled by JS) -->
+      <div id="overlay-end" style="display: none;"></div>
+    </div>
+  </div>
+
+  <!-- RIGHT: NEXT + BEST + CONTROLS -->
+  <div class="side-panel">
+    <div class="panel-box">
+      <div class="panel-title">Next</div>
+      <canvas id="next" class="next-canvas" width="100" height="300"></canvas>
+    </div>
+    <div class="panel-box">
+      <div class="panel-title">Best</div>
+      <div class="panel-value" id="best">0</div>
+    </div>
+    <div class="controls-panel">
+      <h3>Controles</h3>
+      <div class="ctrl-row"><span>Mover</span><span>← →</span></div>
+      <div class="ctrl-row"><span>Girar</span><span>↑ / X</span></div>
+      <div class="ctrl-row"><span>Descer</span><span>↓</span></div>
+      <div class="ctrl-row"><span>Hard drop</span><span>Espaço</span></div>
+      <div class="ctrl-row"><span>Hold</span><span>C / Shift</span></div>
+      <div class="ctrl-row"><span>Pausa</span><span>P</span></div>
+    </div>
+  </div>
+</div>
+
+<!-- MOBILE -->
+<div class="mobile-controls">
+  <div class="mobile-row">
+    <button class="mobile-btn" data-action="hold">Hold</button>
+    <button class="mobile-btn" data-action="rotate">↻</button>
+    <button class="mobile-btn" data-action="pause">Pausa</button>
+  </div>
+  <div class="mobile-row">
+    <button class="mobile-btn" data-action="left">←</button>
+    <button class="mobile-btn" data-action="down">↓</button>
+    <button class="mobile-btn" data-action="right">→</button>
+  </div>
+  <div class="mobile-row">
+    <button class="mobile-btn" data-action="drop" style="max-width: 100%; flex: 2;">DROP</button>
+  </div>
+</div>
+
+<script>
+// ============================================================
+//  TETRIS — vanilla JS
+// ============================================================
+
+const COLS = 10;
+const ROWS = 20;
+const CELL = 30;            // board cell size in px
+const NEXT_CELL = 20;
+const HOLD_CELL = 20;
+
+// Colors per tetromino
+const COLORS = {
+  I: '#00f0f0', O: '#f0f000', T: '#a000f0',
+  S: '#00f000', Z: '#f00000', J: '#0000f0', L: '#f0a000'
+};
+
+// Tetromino shapes (4 rotations each, pre-baked)
+const SHAPES = {
+  I: [
+    [[0,0,0,0],[1,1,1,1],[0,0,0,0],[0,0,0,0]],
+    [[0,0,1,0],[0,0,1,0],[0,0,1,0],[0,0,1,0]],
+    [[0,0,0,0],[0,0,0,0],[1,1,1,1],[0,0,0,0]],
+    [[0,1,0,0],[0,1,0,0],[0,1,0,0],[0,1,0,0]]
+  ],
+  O: [
+    [[1,1],[1,1]],
+    [[1,1],[1,1]],
+    [[1,1],[1,1]],
+    [[1,1],[1,1]]
+  ],
+  T: [
+    [[0,1,0],[1,1,1],[0,0,0]],
+    [[0,1,0],[0,1,1],[0,1,0]],
+    [[0,0,0],[1,1,1],[0,1,0]],
+    [[0,1,0],[1,1,0],[0,1,0]]
+  ],
+  S: [
+    [[0,1,1],[1,1,0],[0,0,0]],
+    [[0,1,0],[0,1,1],[0,0,1]],
+    [[0,0,0],[0,1,1],[1,1,0]],
+    [[1,0,0],[1,1,0],[0,1,0]]
+  ],
+  Z: [
+    [[1,1,0],[0,1,1],[0,0,0]],
+    [[0,0,1],[0,1,1],[0,1,0]],
+    [[0,0,0],[1,1,0],[0,1,1]],
+    [[0,1,0],[1,1,0],[1,0,0]]
+  ],
+  J: [
+    [[1,0,0],[1,1,1],[0,0,0]],
+    [[0,1,1],[0,1,0],[0,1,0]],
+    [[0,0,0],[1,1,1],[0,0,1]],
+    [[0,1,0],[0,1,0],[1,1,0]]
+  ],
+  L: [
+    [[0,0,1],[1,1,1],[0,0,0]],
+    [[0,1,0],[0,1,0],[0,1,1]],
+    [[0,0,0],[1,1,1],[1,0,0]],
+    [[1,1,0],[0,1,0],[0,1,0]]
+  ]
+};
+
+// SRS wall kick data (simplified, works for most pieces)
+const KICKS_JLSTZ = {
+  '0>1': [[0,0],[-1,0],[-1,1],[0,-2],[-1,-2]],
+  '1>0': [[0,0],[1,0],[1,-1],[0,2],[1,2]],
+  '1>2': [[0,0],[1,0],[1,-1],[0,2],[1,2]],
+  '2>1': [[0,0],[-1,0],[-1,1],[0,-2],[-1,-2]],
+  '2>3': [[0,0],[1,0],[1,1],[0,-2],[1,-2]],
+  '3>2': [[0,0],[-1,0],[-1,-1],[0,2],[-1,2]],
+  '3>0': [[0,0],[-1,0],[-1,-1],[0,2],[-1,2]],
+  '0>3': [[0,0],[1,0],[1,1],[0,-2],[1,-2]]
+};
+
+const KICKS_I = {
+  '0>1': [[0,0],[-2,0],[1,0],[-2,-1],[1,2]],
+  '1>0': [[0,0],[2,0],[-1,0],[2,1],[-1,-2]],
+  '1>2': [[0,0],[-1,0],[2,0],[-1,2],[2,-1]],
+  '2>1': [[0,0],[1,0],[-2,0],[1,-2],[-2,1]],
+  '2>3': [[0,0],[2,0],[-1,0],[2,1],[-1,-2]],
+  '3>2': [[0,0],[-2,0],[1,0],[-2,-1],[1,2]],
+  '3>0': [[0,0],[1,0],[-2,0],[1,-2],[-2,1]],
+  '0>3': [[0,0],[-1,0],[2,0],[-1,2],[2,-1]]
+};
+
+// ============================================================
+//  GAME STATE
+// ============================================================
+
+const boardCanvas = document.getElementById('board');
+const ctx = boardCanvas.getContext('2d');
+const nextCanvas = document.getElementById('next');
+const nextCtx = nextCanvas.getContext('2d');
+const holdCanvas = document.getElementById('hold');
+const holdCtx = holdCanvas.getContext('2d');
+const scoreEl = document.getElementById('score');
+const linesEl = document.getElementById('lines');
+const levelEl = document.getElementById('level');
+const bestEl = document.getElementById('best');
+const playerNameEl = document.getElementById('player-name');
+const overlay = document.getElementById('overlay');
+const overlayStart = document.getElementById('overlay-start');
+const overlayEnd = document.getElementById('overlay-end');
+const playerInput = document.getElementById('player-input');
+const playBtn = document.getElementById('play-btn');
+const lastPlayerEl = document.getElementById('last-player');
+
+let grid;              // 2D array [ROWS][COLS]
+let current;           // active piece {type, rot, x, y}
+let nextQueue;         // array of upcoming types
+let heldType;          // piece in hold
+let canHold;           // can swap with hold once per piece
+let score, lines, level;
+let dropCounter, dropInterval;
+let lastTime;
+let running;           // game loop running flag
+let paused;
+let gameOver;
+let bag = [];          // 7-bag generator
+
+// ============================================================
+//  CORE HELPERS
+// ============================================================
+
+function emptyGrid() {
+  return Array.from({length: ROWS}, () => Array(COLS).fill(null));
+}
+
+function refillBag() {
+  const types = Object.keys(SHAPES);
+  // Fisher-Yates shuffle
+  for (let i = types.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [types[i], types[j]] = [types[j], types[i]];
+  }
+  bag.push(...types);
+}
+
+function nextType() {
+  if (bag.length < 7) refillBag();
+  return bag.shift();
+}
+
+function spawn() {
+  const type = nextQueue.shift();
+  if (nextQueue.length < 6) nextQueue.push(nextType());
+  current = {
+    type,
+    rot: 0,
+    x: Math.floor((COLS - SHAPES[type][0][0].length) / 2),
+    y: 0
+  };
+  canHold = true;
+  if (collide(current, 0, 0)) {
+    endGame();
+  }
+}
+
+function rotate(dir) {
+  const newRot = (current.rot + (dir > 0 ? 1 : 3)) % 4;
+  const key = `${current.rot}>${newRot}`;
+  const kicks = (current.type === 'I') ? KICKS_I[key] : KICKS_JLSTZ[key];
+  for (const [dx, dy] of kicks) {
+    if (!collide(current, dx, -dy, newRot)) {
+      current.x += dx;
+      current.y += dy;
+      current.rot = newRot;
+      return;
+    }
+  }
+}
+
+function collide(piece, dx, dy, rot = piece.rot) {
+  const shape = SHAPES[piece.type][rot];
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (!shape[r][c]) continue;
+      const nx = piece.x + c + dx;
+      const ny = piece.y + r + dy;
+      if (nx < 0 || nx >= COLS || ny >= ROWS) return true;
+      if (ny < 0) continue;          // above board is OK
+      if (grid[ny][nx]) return true;
+    }
+  }
+  return false;
+}
+
+function merge() {
+  const shape = SHAPES[current.type][current.rot];
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (shape[r][c]) {
+        const ny = current.y + r;
+        const nx = current.x + c;
+        if (ny >= 0 && ny < ROWS && nx >= 0 && nx < COLS) {
+          grid[ny][nx] = current.type;
+        }
+      }
+    }
+  }
+}
+
+function clearLines() {
+  let cleared = 0;
+  for (let r = ROWS - 1; r >= 0; r--) {
+    if (grid[r].every(cell => cell !== null)) {
+      grid.splice(r, 1);
+      grid.unshift(Array(COLS).fill(null));
+      cleared++;
+      r++; // re-check same index
+    }
+  }
+  if (cleared > 0) {
+    const points = [0, 100, 300, 500, 800][cleared] * level;
+    score += points;
+    lines += cleared;
+    const newLevel = Math.floor(lines / 10) + 1;
+    if (newLevel > level) {
+      level = newLevel;
+      dropInterval = Math.max(80, 800 - (level - 1) * 60);
+    }
+    updateUI();
+  }
+}
+
+function hardDrop() {
+  let dy = 0;
+  while (!collide(current, 0, dy + 1)) dy++;
+  current.y += dy;
+  score += dy * 2;
+  lock();
+}
+
+function softDrop() {
+  if (!collide(current, 0, 1)) {
+    current.y++;
+    score += 1;
+    updateUI();
+  } else {
+    lock();
+  }
+}
+
+function lock() {
+  merge();
+  clearLines();
+  spawn();
+}
+
+function holdPiece() {
+  if (!canHold) return;
+  if (heldType === null) {
+    heldType = current.type;
+    spawn();
+  } else {
+    const swap = heldType;
+    heldType = current.type;
+    current = {
+      type: swap,
+      rot: 0,
+      x: Math.floor((COLS - SHAPES[swap][0][0].length) / 2),
+      y: 0
+    };
+    if (collide(current, 0, 0)) {
+      endGame();
+    }
+  }
+  canHold = false;
+}
+
+// ============================================================
+//  RENDERING
+// ============================================================
+
+function drawCell(ctx, x, y, size, color, ghost = false) {
+  const px = x * size;
+  const py = y * size;
+  if (ghost) {
+    ctx.fillStyle = color + '22';
+    ctx.fillRect(px, py, size, size);
+    ctx.strokeStyle = color + '88';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(px + 0.5, py + 0.5, size - 1, size - 1);
+    return;
+  }
+  // Block body
+  ctx.fillStyle = color;
+  ctx.fillRect(px, py, size, size);
+  // Highlight
+  ctx.fillStyle = 'rgba(255,255,255,0.35)';
+  ctx.fillRect(px, py, size, size * 0.25);
+  ctx.fillRect(px, py, size * 0.25, size);
+  // Shadow
+  ctx.fillStyle = 'rgba(0,0,0,0.35)';
+  ctx.fillRect(px, py + size * 0.75, size, size * 0.25);
+  ctx.fillRect(px + size * 0.75, py, size * 0.25, size);
+  // Outline
+  ctx.strokeStyle = 'rgba(0,0,0,0.6)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(px + 1, py + 1, size - 2, size - 2);
+}
+
+function drawBoard() {
+  // Background grid
+  ctx.fillStyle = '#1c2030';
+  ctx.fillRect(0, 0, boardCanvas.width, boardCanvas.height);
+  ctx.strokeStyle = '#252a40';
+  ctx.lineWidth = 1;
+  for (let i = 1; i < COLS; i++) {
+    ctx.beginPath();
+    ctx.moveTo(i * CELL + 0.5, 0);
+    ctx.lineTo(i * CELL + 0.5, boardCanvas.height);
+    ctx.stroke();
+  }
+  for (let i = 1; i < ROWS; i++) {
+    ctx.beginPath();
+    ctx.moveTo(0, i * CELL + 0.5);
+    ctx.lineTo(boardCanvas.width, i * CELL + 0.5);
+    ctx.stroke();
+  }
+
+  // Locked cells
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (grid[r][c]) {
+        drawCell(ctx, c, r, CELL, COLORS[grid[r][c]]);
+      }
+    }
+  }
+
+  if (gameOver) return;
+
+  // Ghost
+  let ghostY = 0;
+  while (!collide(current, 0, ghostY + 1)) ghostY++;
+  const shape = SHAPES[current.type][current.rot];
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (shape[r][c]) {
+        drawCell(ctx, current.x + c, current.y + r + ghostY, CELL, COLORS[current.type], true);
+      }
+    }
+  }
+
+  // Current piece
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (shape[r][c] && current.y + r >= 0) {
+        drawCell(ctx, current.x + c, current.y + r, CELL, COLORS[current.type]);
+      }
+    }
+  }
+}
+
+function drawMini(ctx, canvas, type) {
+  ctx.fillStyle = '#1c2030';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  if (!type) return;
+  const shape = SHAPES[type][0];
+  // Compute bounding box
+  let minR = 4, maxR = -1, minC = 4, maxC = -1;
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (shape[r][c]) {
+        if (r < minR) minR = r;
+        if (r > maxR) maxR = r;
+        if (c < minC) minC = c;
+        if (c > maxC) maxC = c;
+      }
+    }
+  }
+  const w = (maxC - minC + 1) * HOLD_CELL;
+  const h = (maxR - minR + 1) * HOLD_CELL;
+  const ox = (canvas.width - w) / 2 - minC * HOLD_CELL;
+  const oy = (canvas.height - h) / 2 - minR * HOLD_CELL;
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (shape[r][c]) {
+        drawCell(ctx, ox / HOLD_CELL + c, oy / HOLD_CELL + r, HOLD_CELL, COLORS[type]);
+      }
+    }
+  }
+}
+
+function drawNext() {
+  nextCtx.fillStyle = '#1c2030';
+  nextCtx.fillRect(0, 0, nextCanvas.width, nextCanvas.height);
+  const slotH = nextCanvas.height / 3;
+  for (let i = 0; i < Math.min(3, nextQueue.length); i++) {
+    const type = nextQueue[i];
+    const shape = SHAPES[type][0];
+    let minR = 4, maxR = -1, minC = 4, maxC = -1;
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (shape[r][c]) {
+          if (r < minR) minR = r;
+          if (r > maxR) maxR = r;
+          if (c < minC) minC = c;
+          if (c > maxC) maxC = c;
+        }
+      }
+    }
+    const w = (maxC - minC + 1) * NEXT_CELL;
+    const h = (maxR - minR + 1) * NEXT_CELL;
+    const ox = (nextCanvas.width - w) / 2 - minC * NEXT_CELL;
+    const oy = i * slotH + (slotH - h) / 2 - minR * NEXT_CELL;
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (shape[r][c]) {
+          drawCell(nextCtx, (ox + c * NEXT_CELL) / NEXT_CELL, (oy + r * NEXT_CELL) / NEXT_CELL, NEXT_CELL, COLORS[type]);
+        }
+      }
+    }
+  }
+}
+
+function drawHold() {
+  holdCtx.fillStyle = '#1c2030';
+  holdCtx.fillRect(0, 0, holdCanvas.width, holdCanvas.height);
+  drawMini(holdCtx, holdCanvas, heldType);
+}
+
+function updateUI() {
+  scoreEl.textContent = score.toLocaleString('pt-BR');
+  linesEl.textContent = lines;
+  levelEl.textContent = level;
+  bestEl.textContent = bestScore.toLocaleString('pt-BR');
+  playerNameEl.textContent = playerName;
+}
+
+// ============================================================
+//  GAME LOOP
+// ============================================================
+
+function update(time = 0) {
+  if (!running) return;
+  const delta = time - lastTime;
+  lastTime = time;
+  if (!paused && !gameOver) {
+    dropCounter += delta;
+    if (dropCounter > dropInterval) {
+      softDrop();
+      dropCounter = 0;
+    }
+  }
+  drawBoard();
+  drawNext();
+  drawHold();
+  requestAnimationFrame(update);
+}
+
+// ============================================================
+//  PLAYER NAME + RANKING (localStorage)
+// ============================================================
+
+const STORAGE_NAME = 'tetris.playerName';
+const STORAGE_RANKING = 'tetris.ranking';
+let playerName = localStorage.getItem(STORAGE_NAME) || '';
+let bestScore = 0;
+
+function loadRanking() {
+  try {
+    const data = JSON.parse(localStorage.getItem(STORAGE_RANKING) || '[]');
+    return Array.isArray(data) ? data : [];
+  } catch { return []; }
+}
+
+function saveRankingEntry(name, sc) {
+  const ranking = loadRanking();
+  ranking.push({name, score: sc, when: Date.now()});
+  ranking.sort((a, b) => b.score - a.score);
+  const top = ranking.slice(0, 10);
+  localStorage.setItem(STORAGE_RANKING, JSON.stringify(top));
+  return top;
+}
+
+function getBestScore() {
+  return loadRanking().reduce((m, e) => Math.max(m, e.score), 0);
+}
+
+function commitScore(name, sc) {
+  saveRankingEntry(name, sc);
+  bestScore = getBestScore();
+}
+
+function renderRanking(currentName, currentScore) {
+  const ranking = loadRanking();
+  if (ranking.length === 0) {
+    return '<p style="margin-top: 16px; color: var(--muted); font-size: 12px;">Nenhum score salvo ainda.</p>';
+  }
+  const youHere = ranking.findIndex(e => e.name === currentName && e.score === currentScore);
+  let rows = '';
+  ranking.forEach((e, i) => {
+    const isYou = (e.name === currentName && e.score === currentScore && i === youHere);
+    rows += `<tr class="${isYou ? 'you' : ''}"><td>${i + 1}</td><td>${escapeHtml(e.name)}</td><td>${e.score.toLocaleString('pt-BR')}</td></tr>`;
+  });
+  return `<table class="ranking"><thead><tr><th>#</th><th>Player</th><th>Score</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+// ============================================================
+//  OVERLAY / STATE
+// ============================================================
+
+function showStartOverlay() {
+  overlayEnd.style.display = 'none';
+  overlayStart.style.display = '';
+  overlay.classList.add('active');
+  // Pre-fill input with last name, show hint
+  playerInput.value = playerName;
+  if (playerName) {
+    lastPlayerEl.textContent = `Último jogador: ${playerName}`;
+  } else {
+    lastPlayerEl.textContent = '';
+  }
+  // Clear board canvas so leftover blocks from previous game don't show through
+  ctx.fillStyle = '#1c2030';
+  ctx.fillRect(0, 0, boardCanvas.width, boardCanvas.height);
+  holdCtx.fillStyle = '#1c2030';
+  holdCtx.fillRect(0, 0, holdCanvas.width, holdCanvas.height);
+  nextCtx.fillStyle = '#1c2030';
+  nextCtx.fillRect(0, 0, nextCanvas.width, nextCanvas.height);
+  // Focus on next tick so the click that opened us doesn't break it
+  setTimeout(() => playerInput.focus(), 50);
+}
+
+function showGameOverOverlay(finalScore) {
+  overlayStart.style.display = 'none';
+  overlayEnd.innerHTML = `
+    <h1 style="color: var(--danger); text-shadow: 0 0 12px rgba(255,85,119,0.6);">GAME OVER</h1>
+    <p style="margin: 8px 0 4px; color: var(--muted);">${escapeHtml(playerName)}</p>
+    <p style="font-size: 32px; margin: 6px 0 0; color: var(--accent); text-shadow: var(--glow); font-weight: bold;">${finalScore.toLocaleString('pt-BR')}</p>
+    ${renderRanking(playerName, finalScore)}
+    <button class="primary" id="again-btn" style="margin-top: 20px;">Jogar de novo</button>
+    <p style="margin-top: 10px; font-size: 11px; color: var(--muted);">ou pressione <span class="key">Enter</span></p>
+  `;
+  overlayEnd.style.display = '';
+  overlay.classList.add('active');
+  document.getElementById('again-btn').addEventListener('click', (ev) => {
+    ev.preventDefault();
+    commitScoreAndRestart();
+  });
+}
+
+function hideOverlay() {
+  overlay.classList.remove('active');
+}
+
+function startGame() {
+  // Snapshot name from input if user typed one (and we haven't saved yet)
+  const typed = playerInput.value.trim();
+  if (typed) {
+    playerName = typed.slice(0, 12);
+    localStorage.setItem(STORAGE_NAME, playerName);
+  } else if (!playerName) {
+    playerName = 'Player';
+  }
+  grid = emptyGrid();
+  bag = [];
+  nextQueue = [];
+  for (let i = 0; i < 5; i++) nextQueue.push(nextType());
+  heldType = null;
+  score = 0;
+  lines = 0;
+  level = 1;
+  dropCounter = 0;
+  dropInterval = 800;
+  canHold = true;
+  paused = false;
+  gameOver = false;
+  spawn();
+  updateUI();
+  running = true;
+  lastTime = performance.now();
+  hideOverlay();
+  requestAnimationFrame(update);
+}
+
+function commitScoreAndRestart() {
+  if (score > 0) commitScore(playerName, score);
+  // Clear leftover board state so the start screen looks clean
+  grid = emptyGrid();
+  heldType = null;
+  nextQueue = [];
+  bag = [];
+  score = 0; lines = 0; level = 1;
+  updateUI();
+  showStartOverlay();
+  running = false;
+  gameOver = false;
+}
+
+function togglePause() {
+  if (gameOver || !running) return;
+  paused = !paused;
+  if (paused) {
+    overlayStart.style.display = 'none';
+    overlayEnd.innerHTML = `
+      <h1 style="color: var(--accent); text-shadow: var(--glow);">PAUSADO</h1>
+      <p style="margin-top: 16px;">Pressione <span class="key">P</span> para continuar</p>
+    `;
+    overlayEnd.style.display = '';
+    overlay.classList.add('active');
+  } else hideOverlay();
+}
+
+function endGame() {
+  gameOver = true;
+  running = false;
+  commitScore(playerName, score);
+  updateUI();
+  showGameOverOverlay(score);
+}
+
+// ============================================================
+//  INPUT
+// ============================================================
+
+document.addEventListener('keydown', (e) => {
+  // If focus is on the name input, only Enter (submit) is handled here
+  if (document.activeElement === playerInput) {
+    if (e.code === 'Enter') {
+      e.preventDefault();
+      startGame();
+    }
+    return;
+  }
+  // Start controls (start overlay or game-over overlay)
+  if ((e.code === 'Enter' || e.code === 'Space') && (!running || gameOver)) {
+    e.preventDefault();
+    if (gameOver) {
+      // From game-over overlay: restart goes back to start (keep name)
+      commitScoreAndRestart();
+    } else {
+      startGame();
+    }
+    return;
+  }
+  if (!running || paused || gameOver) {
+    if (e.code === 'KeyP' && running && !gameOver) togglePause();
+    return;
+  }
+
+  switch (e.code) {
+    case 'ArrowLeft':
+      if (!collide(current, -1, 0)) current.x--;
+      e.preventDefault();
+      break;
+    case 'ArrowRight':
+      if (!collide(current, 1, 0)) current.x++;
+      e.preventDefault();
+      break;
+    case 'ArrowDown':
+      softDrop();
+      e.preventDefault();
+      break;
+    case 'ArrowUp':
+    case 'KeyX':
+      rotate(1);
+      e.preventDefault();
+      break;
+    case 'KeyZ':
+      rotate(-1);
+      e.preventDefault();
+      break;
+    case 'Space':
+      hardDrop();
+      e.preventDefault();
+      break;
+    case 'KeyC':
+    case 'ShiftLeft':
+    case 'ShiftRight':
+      holdPiece();
+      e.preventDefault();
+      break;
+    case 'KeyP':
+      togglePause();
+      break;
+  }
+});
+
+// Play button click
+playBtn.addEventListener('click', (e) => {
+  e.preventDefault();
+  startGame();
+});
+
+// Mobile buttons
+document.querySelectorAll('.mobile-btn').forEach(btn => {
+  const action = btn.dataset.action;
+  const fire = (ev) => {
+    ev.preventDefault();
+    if (!running && !gameOver) {
+      // From start overlay, tap drop/rotate/pause = play (start)
+      if (action === 'drop' || action === 'rotate' || action === 'pause') startGame();
+      return;
+    }
+    if (gameOver) {
+      if (action === 'drop' || action === 'rotate') commitScoreAndRestart();
+      return;
+    }
+    if (action === 'pause') { togglePause(); return; }
+    if (paused || !running) return;
+    switch (action) {
+      case 'left':  if (!collide(current, -1, 0)) current.x--; break;
+      case 'right': if (!collide(current, 1, 0)) current.x++; break;
+      case 'down':  softDrop(); break;
+      case 'rotate': rotate(1); break;
+      case 'hold':   holdPiece(); break;
+      case 'drop':   hardDrop(); break;
+    }
+  };
+  btn.addEventListener('touchstart', fire, {passive: false});
+  btn.addEventListener('mousedown', fire);
+});
+
+// Detect iframe embedding. When loaded inside the Brenon.Cloud Games
+// page, switch to a compact layout that fits the 760x720 iframe box.
+// (We don't intercept keys: Tetris already listens at document-level, so
+// arrow keys stay focused on the game. If the user clicks outside the
+// iframe, the host page can take over scrolling again naturally.)
+try {
+  if (window.self !== window.top) {
+    document.body.classList.add('embedded');
+  }
+} catch (err) {
+  // Cross-origin frame access can throw — safe to ignore.
+}
+
+// Initial overlay
+bestScore = getBestScore();
+playerNameEl.textContent = playerName || '—';
+bestEl.textContent = bestScore.toLocaleString('pt-BR');
+showStartOverlay();
+</script>
+</body>
+</html>

--- a/src/api/gamesApi.js
+++ b/src/api/gamesApi.js
@@ -1,0 +1,88 @@
+/**
+ * Games API Client
+ * Loads game entries from local JSON manifests at build time.
+ *
+ * Files live in `src/content/games/*.json`. The filename encodes both the
+ * game slug and (optionally) its locale, mirroring the blog convention:
+ *
+ *   tetris.json            -> slug=tetris, locale=null (fallback)
+ *   tetris.en.json         -> slug=tetris, locale=en
+ *   tetris.pt.json         -> slug=tetris, locale=pt
+ *
+ * If the suffix is not a recognized locale, it is treated as part of the
+ * slug (e.g. `release-1.2.json` stays a single entry).
+ *
+ * The neutral file is mandatory and carries the technical config
+ * (iframe path, dimensions, score unit) that does not change per locale.
+ * Per-locale files only override translatable strings (title, description).
+ */
+
+const rawEntries = import.meta.glob('../content/games/*.json', {
+  query: '?raw',
+  import: 'default',
+  eager: true
+})
+
+const LOCALE_ALIASES = {
+  en: 'en',
+  eng: 'en',
+  pt: 'pt',
+  ptbr: 'pt',
+  'pt-br': 'pt'
+}
+
+export function normalizeLocale(value) {
+  if (!value) return null
+  return LOCALE_ALIASES[value.toLowerCase()] || null
+}
+
+export function parseFilename(path) {
+  const name = path.split('/').pop().replace(/\.json$/, '')
+  const match = name.match(/^(.+)\.([A-Za-z-]{2,5})$/)
+  if (match) {
+    const locale = normalizeLocale(match[2])
+    if (locale) {
+      return { slug: match[1], locale }
+    }
+  }
+  return { slug: name, locale: null }
+}
+
+function safeParse(raw, source) {
+  try {
+    return JSON.parse(raw)
+  } catch (err) {
+    console.error(`[gamesApi] failed to parse ${source}:`, err)
+    return null
+  }
+}
+
+export class GamesApiClient {
+  /**
+   * Returns every raw JSON entry along with the slug and locale derived
+   * from the filename.
+   * @returns {Promise<Array<{ slug: string, locale: string|null, data: object }>>}
+   */
+  async getRawEntries() {
+    const out = []
+    for (const [path, raw] of Object.entries(rawEntries)) {
+      const { slug, locale } = parseFilename(path)
+      const data = safeParse(raw, path)
+      if (!data) continue
+      out.push({ slug, locale, data })
+    }
+    return out
+  }
+
+  /**
+   * Returns every raw entry that matches a slug (across all locales).
+   * @param {string} slug
+   * @returns {Promise<Array<{ slug: string, locale: string|null, data: object }>>}
+   */
+  async getRawEntriesBySlug(slug) {
+    const entries = await this.getRawEntries()
+    return entries.filter(e => e.slug === slug)
+  }
+}
+
+export const gamesApi = new GamesApiClient()

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -124,6 +124,7 @@ const isMobileMenuOpen = ref(false)
 
 const menuItems = computed(() => [
   { to: '/blog', text: t('navbar.blog'), route: true },
+  { to: '/games', text: t('navbar.games'), route: true },
   { to: '/path', text: t('navbar.pathToGlory'), route: true },
   { to: 'infrastructure', text: t('navbar.about') },
   { to: 'https://uptime.brenon.cloud/status/services', text: t('navbar.status'), external: true }

--- a/src/composables/useGames.js
+++ b/src/composables/useGames.js
@@ -1,0 +1,33 @@
+import { computed, inject } from 'vue'
+import { useGamesStore } from '../stores/gamesStore'
+import { useI18n } from 'vue-i18n'
+
+/**
+ * Games Composable
+ * Reactive entry point for components. Catalog and individual games are
+ * resolved against the active i18n locale; switching language re-fetches.
+ */
+export function useGames() {
+  const store = useGamesStore()
+  const gamesService = inject('gamesService')
+  const { locale } = useI18n()
+
+  const loadGames = (force = false) =>
+    store.fetchGames(gamesService, locale.value, force)
+
+  const loadGame = (slug, force = false) =>
+    store.fetchGameBySlug(gamesService, slug, locale.value, force)
+
+  const games = computed(() => store.getGames(locale.value))
+  const loading = computed(() => store.isLoading)
+  const error = computed(() => store.error)
+
+  return {
+    games,
+    loading,
+    error,
+    locale,
+    loadGames,
+    loadGame
+  }
+}

--- a/src/content/games/tetris.json
+++ b/src/content/games/tetris.json
@@ -1,0 +1,10 @@
+{
+  "title": "Tetris",
+  "description": "Stack blocks, clear lines, chase your high score. The classic falling-block puzzle.",
+  "category": "puzzle",
+  "players": "single",
+  "scoreUnit": "points",
+  "iframe": "/games/tetris.html",
+  "width": 760,
+  "height": 720
+}

--- a/src/content/games/tetris.pt.json
+++ b/src/content/games/tetris.pt.json
@@ -1,0 +1,4 @@
+{
+  "title": "Tetris",
+  "description": "Empilhe blocos, elimine linhas e persiga sua maior pontuação. O clássico quebra-cabeça de blocos que caem."
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -213,6 +213,7 @@
     "services": "Services",
     "about": "Infrastructure",
     "blog": "Blog",
+    "games": "Games",
     "pathToGlory": "Path to Glory",
     "status": "Status"
   },
@@ -236,6 +237,35 @@
     "notFound": {
       "title": "Post not found",
       "description": "This article does not exist or was moved."
+    }
+  },
+  "games": {
+    "title": "Browser Games",
+    "subtitle": "Small games built for the browser. Play, chase a high score, and keep your best runs.",
+    "play": "Play now",
+    "backToList": "Back to all games",
+    "translationFallback": "Available in this language only",
+    "scoreStoredHint": "Best scores and history are kept locally in your browser ({unit}).",
+    "empty": {
+      "title": "No games yet",
+      "description": "The first games are on the way — check back soon."
+    },
+    "notFound": {
+      "title": "Game not found",
+      "description": "This game does not exist or was removed."
+    },
+    "playersSingle": "Single player",
+    "playersMulti": "Local multiplayer",
+    "categories": {
+      "puzzle": "Puzzle",
+      "arcade": "Arcade",
+      "action": "Action",
+      "casual": "Casual"
+    },
+    "units": {
+      "points": "points",
+      "lines": "lines",
+      "ms": "milliseconds"
     }
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -213,6 +213,7 @@
     "services": "Serviços",
     "about": "Infraestrutura",
     "blog": "Blog",
+    "games": "Jogos",
     "pathToGlory": "Caminho para a Glória",
     "status": "Status"
   },
@@ -236,6 +237,35 @@
     "notFound": {
       "title": "Post não encontrado",
       "description": "Este artigo não existe ou foi movido."
+    }
+  },
+  "games": {
+    "title": "Jogos no Navegador",
+    "subtitle": "Pequenos jogos feitos para o navegador. Jogue, persiga pontuações e guarde suas melhores partidas.",
+    "play": "Jogar agora",
+    "backToList": "Voltar para todos os jogos",
+    "translationFallback": "Disponível apenas neste idioma",
+    "scoreStoredHint": "Pontuações e histórico ficam guardados localmente no seu navegador ({unit}).",
+    "empty": {
+      "title": "Nenhum jogo ainda",
+      "description": "Os primeiros jogos estão a caminho — volte em breve."
+    },
+    "notFound": {
+      "title": "Jogo não encontrado",
+      "description": "Este jogo não existe ou foi removido."
+    },
+    "playersSingle": "Um jogador",
+    "playersMulti": "Multijogador local",
+    "categories": {
+      "puzzle": "Puzzle",
+      "arcade": "Arcade",
+      "action": "Ação",
+      "casual": "Casual"
+    },
+    "units": {
+      "points": "pontos",
+      "lines": "linhas",
+      "ms": "milissegundos"
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -11,12 +11,16 @@ import Service from './pages/Service.vue'
 import Blog from './pages/Blog.vue'
 import BlogPost from './pages/BlogPost.vue'
 import PathToGlory from './pages/PathToGlory.vue'
+import Games from './pages/Games.vue'
+import GamePlayer from './pages/GamePlayer.vue'
 
 // Clean Architecture Layers
 import { servicesApi } from './api/servicesApi'
 import { ServiceService } from './services/serviceService'
 import { blogApi } from './api/blogApi'
 import { BlogService } from './services/blogService'
+import { gamesApi } from './api/gamesApi'
+import { GamesService } from './services/gamesService'
 
 // i18n translations
 import en from './locales/en.json'
@@ -54,6 +58,17 @@ const router = createRouter({
       component: PathToGlory
     },
     {
+      path: '/games',
+      name: 'games',
+      component: Games
+    },
+    {
+      path: '/games/:slug',
+      name: 'game-player',
+      component: GamePlayer,
+      props: true
+    },
+    {
       path: '/status',
       beforeEnter: (to, from, next) => {
         window.location.href = 'https://uptime.brenon.cloud/status/services';
@@ -88,6 +103,7 @@ const i18n = createI18n({
 // Dependency Injection: Service Layer
 const serviceService = new ServiceService(servicesApi)
 const blogService = new BlogService(blogApi)
+const gamesService = new GamesService(gamesApi)
 
 // Create and configure app
 const app = createApp(App)
@@ -100,5 +116,6 @@ app.use(i18n)
 // Provide dependencies (Dependency Injection)
 app.provide('serviceService', serviceService)
 app.provide('blogService', blogService)
+app.provide('gamesService', gamesService)
 
 app.mount('#app')

--- a/src/pages/GamePlayer.vue
+++ b/src/pages/GamePlayer.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
+    <!-- Header with back link + title -->
+    <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-8">
+      <div>
+        <router-link
+          to="/games"
+          class="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors mb-3"
+        >
+          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          {{ t('games.backToList') }}
+        </router-link>
+        <h1 class="text-3xl sm:text-4xl font-bold text-white tracking-tight">
+          {{ game?.title || slug }}
+        </h1>
+        <p v-if="game?.description" class="mt-2 text-gray-300 max-w-2xl">
+          {{ game.description }}
+        </p>
+      </div>
+      <div v-if="game" class="flex flex-wrap items-center gap-2">
+        <span class="px-2.5 py-1 rounded-md bg-blue-500/10 text-blue-300 border border-blue-500/20 text-xs uppercase tracking-wide">
+          {{ t(`games.categories.${game.category}`, game.category) }}
+        </span>
+        <span class="px-2.5 py-1 rounded-md bg-gray-700/40 text-gray-300 border border-gray-600/40 text-xs uppercase tracking-wide">
+          {{ game.players === 'multi' ? t('games.playersMulti') : t('games.playersSingle') }}
+        </span>
+        <span
+          v-if="game.locale && game.locale !== locale"
+          class="px-2.5 py-1 rounded-md bg-amber-500/10 text-amber-300 border border-amber-500/20 text-xs uppercase tracking-wide"
+        >
+          {{ game.locale }}
+        </span>
+      </div>
+    </div>
+
+    <div v-if="loading" class="text-center py-12">
+      <div class="inline-block animate-spin rounded-full h-12 w-12 border-4 border-gray-600 border-t-blue-500"></div>
+      <p class="mt-4 text-gray-400">{{ t('common.loading') }}</p>
+    </div>
+
+    <div v-else-if="error || !game" class="text-center py-12">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-red-500/10 mb-6">
+        <svg class="w-8 h-8 text-red-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <h2 class="text-2xl font-semibold text-white mb-2">{{ t('games.notFound.title') }}</h2>
+      <p class="text-gray-400 max-w-md mx-auto mb-6">
+        {{ error ? `${t('common.error')}: ${error}` : t('games.notFound.description') }}
+      </p>
+      <router-link
+        to="/games"
+        class="inline-block px-5 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white"
+      >
+        {{ t('games.backToList') }}
+      </router-link>
+    </div>
+
+    <!-- Iframe container. We center it and let the game dictate its
+         own intrinsic size; the page background keeps the dark theme.
+         max-height keeps very tall games from forcing the user to scroll
+         past the host page on small screens. -->
+    <div
+      v-else
+      class="flex justify-center"
+    >
+      <div
+        class="relative w-full max-w-full rounded-2xl overflow-hidden border border-gray-700/60 bg-gray-900 shadow-2xl"
+        :style="{
+          aspectRatio: `${game.width} / ${game.height}`,
+          maxHeight: '78vh'
+        }"
+      >
+        <iframe
+          :key="iframeKey"
+          :src="game.iframe"
+          :title="game.title"
+          class="absolute inset-0 w-full h-full bg-gray-900"
+          frameborder="0"
+          allow="autoplay; fullscreen"
+          allowfullscreen
+          referrerpolicy="no-referrer"
+        ></iframe>
+      </div>
+    </div>
+
+    <!-- Tips / footer about the game -->
+    <p
+      v-if="game"
+      class="mt-6 text-center text-xs text-gray-500"
+    >
+      {{ t('games.scoreStoredHint', { unit: t(`games.units.${game.scoreUnit}`, game.scoreUnit) }) }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
+import { useGames } from '../composables/useGames'
+
+const { t } = useI18n()
+const route = useRoute()
+const slug = computed(() => String(route.params.slug || ''))
+const { games, loading, error, locale, loadGame } = useGames()
+
+// Force iframe remount on locale/slug change so the embedded game
+// re-bootstraps with fresh state instead of carrying over a stale frame.
+const iframeKey = computed(() => `${slug.value}-${locale.value}`)
+
+const game = ref(null)
+const syncGame = async () => {
+  if (!slug.value) return
+  game.value = await loadGame(slug.value)
+}
+
+onMounted(syncGame)
+watch(slug, syncGame)
+watch(locale, syncGame)
+</script>

--- a/src/pages/Games.vue
+++ b/src/pages/Games.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+    <header class="text-center mb-16">
+      <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold text-white mb-6 tracking-tight">
+        <span class="bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-emerald-400">
+          {{ t('games.title') }}
+        </span>
+      </h1>
+      <p class="text-lg sm:text-xl text-gray-300 max-w-2xl mx-auto leading-relaxed">
+        {{ t('games.subtitle') }}
+      </p>
+    </header>
+
+    <div v-if="loading" class="text-center py-12">
+      <div class="inline-block animate-spin rounded-full h-12 w-12 border-4 border-gray-600 border-t-blue-500"></div>
+      <p class="mt-4 text-gray-400">{{ t('common.loading') }}</p>
+    </div>
+
+    <div v-else-if="error" class="text-center py-12">
+      <p class="text-red-400 mb-4">{{ t('common.error') }}: {{ error }}</p>
+      <button
+        @click="loadGames(true)"
+        class="px-5 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white"
+      >
+        {{ t('common.retry') }}
+      </button>
+    </div>
+
+    <div v-else-if="!games.length" class="text-center py-16">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-blue-500/10 mb-6">
+        <svg class="w-8 h-8 text-blue-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M14.752 11.168l-5.197-3.03A1 1 0 008 9v6a1 1 0 001.555.832l5.197-3.03a1 1 0 000-1.664z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <h2 class="text-2xl font-semibold text-white mb-2">{{ t('games.empty.title') }}</h2>
+      <p class="text-gray-400 max-w-md mx-auto">{{ t('games.empty.description') }}</p>
+    </div>
+
+    <div v-else class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <router-link
+        v-for="game in games"
+        :key="game.slug"
+        :to="`/games/${game.slug}`"
+        class="group flex flex-col bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 rounded-2xl overflow-hidden hover:border-blue-500/60 hover:bg-gray-800/70 transition-all duration-200"
+      >
+        <!-- Preview tile: gradient background + glyph + category badge -->
+        <div
+          class="relative aspect-[16/9] overflow-hidden bg-gradient-to-br"
+          :class="categoryGradient(game.category)"
+        >
+          <div class="absolute inset-0 flex items-center justify-center">
+            <span class="text-6xl font-black text-white/15 tracking-widest uppercase">
+              {{ game.slug }}
+            </span>
+          </div>
+          <div class="absolute top-3 left-3 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-xs text-white/80 uppercase tracking-wide border border-white/10">
+            {{ t(`games.categories.${game.category}`, game.category) }}
+          </div>
+          <div
+            v-if="game.locale && game.locale !== locale"
+            class="absolute top-3 right-3 px-2 py-0.5 rounded-md bg-amber-500/10 text-amber-300 border border-amber-500/20 uppercase tracking-wide text-xs"
+            :title="t('games.translationFallback')"
+          >
+            {{ game.locale }}
+          </div>
+        </div>
+
+        <div class="p-6 flex flex-col flex-1">
+          <h2 class="text-xl font-semibold text-white mb-2 group-hover:text-blue-400 transition-colors">
+            {{ game.title }}
+          </h2>
+          <p class="text-gray-300 text-sm leading-relaxed flex-1">
+            {{ game.description }}
+          </p>
+          <div class="mt-6 inline-flex items-center gap-2 text-blue-400 text-sm font-medium">
+            {{ t('games.play') }}
+            <svg class="w-4 h-4 transition-transform group-hover:translate-x-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M13 5l7 7-7 7" />
+            </svg>
+          </div>
+        </div>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useGames } from '../composables/useGames'
+
+const { t } = useI18n()
+const { games, loading, error, locale, loadGames } = useGames()
+
+const CATEGORY_GRADIENTS = {
+  puzzle: 'from-blue-500/30 via-purple-500/20 to-gray-900',
+  arcade: 'from-pink-500/30 via-rose-500/20 to-gray-900',
+  action: 'from-orange-500/30 via-red-500/20 to-gray-900',
+  casual: 'from-emerald-500/30 via-teal-500/20 to-gray-900'
+}
+
+const categoryGradient = (cat) => CATEGORY_GRADIENTS[cat] || CATEGORY_GRADIENTS.arcade
+
+onMounted(() => loadGames())
+watch(locale, () => loadGames())
+</script>

--- a/src/services/gamesService.js
+++ b/src/services/gamesService.js
@@ -1,0 +1,106 @@
+/**
+ * Games Service
+ * Resolves game entries against an i18n locale and merges per-locale
+ * translations on top of the neutral (technical) manifest.
+ *
+ * Resolution order for a given slug:
+ *   1. exact locale match       (tetris.pt.json)
+ *   2. neutral fallback file    (tetris.json)
+ *   3. first available locale
+ *
+ * The neutral file is required because it carries the runtime config
+ * (iframe path, dimensions, score unit). A slug with no neutral file is
+ * silently dropped.
+ */
+
+export class GamesService {
+  /**
+   * @param {import('../api/gamesApi').GamesApiClient} apiClient
+   */
+  constructor(apiClient) {
+    this.apiClient = apiClient
+  }
+
+  /**
+   * Returns all games resolved for the given locale, in stable order
+   * (sorted by slug so the catalog doesn't shuffle between locales).
+   *
+   * @param {string} locale
+   * @returns {Promise<import('../types/game').Game[]>}
+   */
+  async getAllGames(locale = 'en') {
+    const raw = await this.apiClient.getRawEntries()
+    const grouped = new Map()
+    for (const entry of raw) {
+      if (!grouped.has(entry.slug)) grouped.set(entry.slug, [])
+      grouped.get(entry.slug).push(entry)
+    }
+
+    const games = []
+    for (const [slug, variants] of grouped) {
+      const picked = this._pickVariant(variants, locale)
+      if (!picked) continue
+      const neutral = variants.find(v => v.locale === null)
+      if (!neutral) continue  // neutral manifest is required
+      const game = this._toGame(slug, neutral.data, picked.data)
+      if (!game) continue
+      game.availableLocales = variants
+        .map(v => v.locale)
+        .filter(Boolean)
+      games.push(game)
+    }
+
+    games.sort((a, b) => a.slug.localeCompare(b.slug))
+    return games
+  }
+
+  /**
+   * Returns a single game by slug for the requested locale.
+   *
+   * @param {string} slug
+   * @param {string} locale
+   * @returns {Promise<import('../types/game').Game | null>}
+   */
+  async getGameBySlug(slug, locale = 'en') {
+    const variants = await this.apiClient.getRawEntriesBySlug(slug)
+    if (!variants.length) return null
+    const neutral = variants.find(v => v.locale === null)
+    if (!neutral) return null
+    const picked = this._pickVariant(variants, locale) || neutral
+    const game = this._toGame(slug, neutral.data, picked.data)
+    if (!game) return null
+    game.availableLocales = variants.map(v => v.locale).filter(Boolean)
+    return game
+  }
+
+  _pickVariant(variants, locale) {
+    return (
+      variants.find(v => v.locale === locale) ||
+      variants.find(v => v.locale === null) ||
+      variants[0] ||
+      null
+    )
+  }
+
+  _toGame(slug, neutralData, localeData) {
+    // localeData may only override title/description; everything else comes
+    // from the neutral manifest. We trust the neutral file for config.
+    const merged = { ...neutralData, ...localeData }
+    if (!merged.iframe) return null  // a game without an iframe cannot run
+    return {
+      slug,
+      locale: localeData && localeData !== neutralData
+        ? (localeData.locale || null)
+        : null,
+      title: merged.title || slug,
+      description: merged.description || '',
+      category: merged.category || 'arcade',
+      players: merged.players || 'single',
+      scoreUnit: merged.scoreUnit || 'points',
+      iframe: merged.iframe,
+      width: Number(merged.width) || 1100,
+      height: Number(merged.height) || 720,
+      availableLocales: []
+    }
+  }
+}

--- a/src/stores/gamesStore.js
+++ b/src/stores/gamesStore.js
@@ -1,0 +1,78 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+/**
+ * Games Store
+ * Caches the game catalog per locale. Mirrors blogStore's caching
+ * strategy so the Games page loads instantly on locale switches.
+ */
+export const useGamesStore = defineStore('games', () => {
+  const gamesByLocale = ref({})  // { en: Game[], pt: Game[] }
+  const gameByLocale = ref({})   // { 'en:tetris': Game }
+  const loading = ref(false)
+  const error = ref(null)
+  const lastFetch = ref({})      // { en: timestamp }
+
+  const CACHE_TTL_MS = 5 * 60 * 1000  // 5 minutes
+
+  const isCacheValid = (locale) => {
+    const ts = lastFetch.value[locale]
+    return ts && Date.now() - ts < CACHE_TTL_MS
+  }
+
+  const fetchGames = async (gamesService, locale, force = false) => {
+    if (!force && gamesByLocale.value[locale] && isCacheValid(locale)) {
+      return gamesByLocale.value[locale]
+    }
+    loading.value = true
+    error.value = null
+    try {
+      const games = await gamesService.getAllGames(locale)
+      gamesByLocale.value = { ...gamesByLocale.value, [locale]: games }
+      lastFetch.value = { ...lastFetch.value, [locale]: Date.now() }
+      return games
+    } catch (err) {
+      error.value = err.message || String(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const fetchGameBySlug = async (gamesService, slug, locale, force = false) => {
+    const key = `${locale}:${slug}`
+    if (!force && gameByLocale.value[key] && isCacheValid(locale)) {
+      return gameByLocale.value[key]
+    }
+    loading.value = true
+    error.value = null
+    try {
+      const game = await gamesService.getGameBySlug(slug, locale)
+      if (game) {
+        gameByLocale.value = { ...gameByLocale.value, [key]: game }
+        // Refresh last-fetch so the per-slug entry benefits from the same TTL.
+        lastFetch.value = { ...lastFetch.value, [locale]: Date.now() }
+      }
+      return game
+    } catch (err) {
+      error.value = err.message || String(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const getGames = (locale) => gamesByLocale.value[locale] || []
+  const getGame = (locale, slug) => gameByLocale.value[`${locale}:${slug}`] || null
+
+  return {
+    gamesByLocale,
+    gameByLocale,
+    loading,
+    error,
+    fetchGames,
+    fetchGameBySlug,
+    getGames,
+    getGame
+  }
+})

--- a/src/types/game.js
+++ b/src/types/game.js
@@ -1,0 +1,21 @@
+/**
+ * @typedef {Object} Game
+ * @property {string} slug            Stable identifier used in the URL.
+ * @property {string|null} locale      Locale of the variant that was
+ *                                    resolved, or null if the neutral
+ *                                    file was picked as a fallback.
+ * @property {string} title           Display title (i18n-resolved).
+ * @property {string} description     Short tagline (i18n-resolved).
+ * @property {string} category        e.g. "puzzle", "arcade", "action".
+ * @property {string} players         "single" | "multi" (local hot-seat).
+ * @property {string} scoreUnit       e.g. "points", "lines", "ms".
+ * @property {string} iframe          Path to the standalone game file
+ *                                    under /public (e.g. /games/tetris.html).
+ * @property {number} width           Iframe preferred width in px.
+ * @property {number} height          Iframe preferred height in px.
+ * @property {string[]} availableLocales  Locales for which a translation
+ *                                    variant exists (excluding the
+ *                                    neutral fallback).
+ */
+
+export {}


### PR DESCRIPTION
## Summary

Adds a new **Browser Games** section at `/games` that hosts small standalone browser games embedded in iframes. **Tetris** ships as the first game, with per-browser score history stored in `localStorage`.

Decided up-front (no backend needed): rankings are kept in the player's browser only — simpler to maintain, no infra cost, matches Brenon.Cloud's static-Netto.

## What's in here

### New feature surface
- `/games` — catalog grid (one card per game, EN/PT-aware)
- `/games/:slug` — player page with iframe + aspect-ratio + max-height cap
- New "Games" link in the navbar, between Blog and Path to Glory

### Architecture (mirrors the blog split)
- `src/api/gamesApi.js` — `import.meta.glob` over `src/content/games/*.json`, locale suffix parsing (`tetris.json` neutral, `tetris.pt.json` overrides)
- `src/services/gamesService.js` — merges per-locale over neutral, sorted catalog
- `src/stores/gamesStore.js` — Pinia + 5-min cache per locale
- `src/composables/useGames.js` — DI-aware wrapper (`gamesService` injected, same as `blogService`)
- `src/types/game.js` — JSDoc typedefs
- `src/pages/Games.vue` / `src/pages/GamePlayer.vue`

### Tetris
- `public/games/tetris.html` — single-file vanilla JS clone
- Detects iframe embedding via `window.self !== window.top` and switches to a compact `.embedded` stylesheet that fits the 760x720 iframe box
- Start overlay, name input, score, levels, hold, ghost piece, pause, mobile controls
- Top 10 ranking per browser under `tetris.ranking` / `tetris.playerName` localStorage keys

### i18n
- Added `games` namespace to both `en.json` and `pt.json` (categories, units, players, empty/notFound, etc.)
- Added `navbar.games` to both locales

### Deploy
- `netlify.toml` gains a `/games/*` redirect that serves standalone game files first, before the SPA fallback catches them. So `/games/tetris.html` resolves to the static file, while `/games/tetris` (no extension) still falls through to the Vue router.

## How to add a new game

Three files (full guide in `public/games/README.md`):
1. Drop a standalone HTML game in `public/games/<slug>.html`
2. Write a neutral manifest at `src/content/games/<slug>.json` with `iframe`, `width`, `height`, `category`, `scoreUnit`, etc.
3. Optionally add `src/content/games/<slug>.<locale>.json` for translations

The catalog picks it up on the next build.

## Test plan

- [x] `npm run build` passes in ~3.5s
- [x] `/` -> navbar shows Blog / Games / Path to Glory / Infrastructure / Status
- [x] `/games` -> "Browser Games" gradient title + Tetris card (PUZZLE badge, Play now / Jogar agora)
- [x] EN/PT toggle re-renders everything
- [x] `/games/tetris` -> iframe loads, start overlay with name input works
- [x] End-to-end playthrough inside the iframe: drop / game over / ranking highlights current player / score persists to `localStorage`
- [x] Best score panel updates correctly after game over
- [x] localStorage keys are scoped per game (`tetris.ranking` - future games use their own prefix)

## Out of scope (deliberately)

- No server-side leaderboards (would require backend; not justified by usage)
- No cross-device sync (localStorage is per-browser by design)
- No audio (kept it silent for the first ship; can add later)
