### PR TITLE
feat(blog): agentic loop engineering — SDD, SPDD, BMAD, harness & loop engineering with Hermes + MiniMax M3 + GLM 5.2

### DIFF
--- a/public/images/blog/agentic-harness-architecture.svg
+++ b/public/images/blog/agentic-harness-architecture.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 500" width="1000" height="500">
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1000" height="500" fill="url(#bg2)" rx="12"/>
+
+  <!-- Title -->
+  <text x="500" y="35" text-anchor="middle" fill="#f1f5f9" font-family="sans-serif" font-size="18" font-weight="bold">Harness Architecture: Hermes + Kanban + GitHub</text>
+
+  <!-- Layer 1: Orchestrator -->
+  <g transform="translate(400, 60)">
+    <rect width="200" height="50" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+    <text x="100" y="22" text-anchor="middle" fill="#3b82f6" font-family="monospace" font-size="11" font-weight="bold">ORCHESTRATOR</text>
+    <text x="100" y="38" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">Hermes Parent Session</text>
+  </g>
+
+  <!-- Arrow down -->
+  <line x1="500" y1="110" x2="500" y2="130" stroke="#3b82f6" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+  <!-- Layer 2: Kanban Board -->
+  <g transform="translate(300, 130)">
+    <rect width="400" height="55" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="200" y="22" text-anchor="middle" fill="#8b5cf6" font-family="monospace" font-size="11" font-weight="bold">KANBAN BOARD (SQLite)</text>
+    <text x="200" y="38" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">Tasks · Dependencies · Assignees · Status</text>
+  </g>
+
+  <!-- Arrows down to workers -->
+  <line x1="350" y1="185" x2="200" y2="215" stroke="#10b981" stroke-width="2" stroke-dasharray="4 2"/>
+  <line x1="500" y1="185" x2="500" y2="215" stroke="#10b981" stroke-width="2"/>
+  <line x1="650" y1="185" x2="800" y2="215" stroke="#10b981" stroke-width="2" stroke-dasharray="4 2"/>
+
+  <!-- Layer 3: Workers (parallel) -->
+  <g transform="translate(80, 215)">
+    <rect width="160" height="80" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+    <text x="80" y="22" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="10" font-weight="bold">WORKER A</text>
+    <text x="80" y="40" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">delegate_task</text>
+    <text x="80" y="55" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">leaf agent</text>
+    <text x="80" y="70" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">isolated context</text>
+  </g>
+
+  <g transform="translate(420, 215)">
+    <rect width="160" height="80" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+    <text x="80" y="22" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="10" font-weight="bold">WORKER B</text>
+    <text x="80" y="40" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">delegate_task</text>
+    <text x="80" y="55" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">leaf agent</text>
+    <text x="80" y="70" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">isolated context</text>
+  </g>
+
+  <g transform="translate(760, 215)">
+    <rect width="160" height="80" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+    <text x="80" y="22" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="10" font-weight="bold">WORKER C</text>
+    <text x="80" y="40" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">delegate_task</text>
+    <text x="80" y="55" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">leaf agent</text>
+    <text x="80" y="70" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="8">isolated context</text>
+  </g>
+
+  <!-- Arrows down to GitHub -->
+  <line x1="160" y1="295" x2="400" y2="325" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4 2"/>
+  <line x1="500" y1="295" x2="500" y2="325" stroke="#f59e0b" stroke-width="1.5"/>
+  <line x1="840" y1="295" x2="600" y2="325" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4 2"/>
+
+  <!-- Layer 4: GitHub Integration -->
+  <g transform="translate(280, 325)">
+    <rect width="440" height="50" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+    <text x="220" y="22" text-anchor="middle" fill="#f59e0b" font-family="monospace" font-size="11" font-weight="bold">GITHUB INTEGRATION</text>
+    <text x="220" y="38" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">gh CLI · PRs · CI/CD · Code Review · Issues</text>
+  </g>
+
+  <!-- Arrow down -->
+  <line x1="500" y1="375" x2="500" y2="395" stroke="#06b6d4" stroke-width="2"/>
+
+  <!-- Layer 5: Testing & Verification -->
+  <g transform="translate(200, 395)">
+    <rect width="600" height="55" rx="8" fill="#1e293b" stroke="#06b6d4" stroke-width="2"/>
+    <text x="300" y="22" text-anchor="middle" fill="#06b6d4" font-family="monospace" font-size="11" font-weight="bold">TESTING &amp; VERIFICATION LAYER</text>
+    <text x="300" y="38" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">Unit · E2E · Smoke · Load Tests · Performance Benchmarks</text>
+  </g>
+
+  <!-- Feedback arrow (loop) -->
+  <path d="M 800,425 Q 950,425 950,300 Q 950,85 600,85" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6 3" opacity="0.6"/>
+  <text x="930" y="200" text-anchor="middle" fill="#ef4444" font-family="monospace" font-size="8" opacity="0.6">FEEDBACK LOOP</text>
+</svg>

--- a/public/images/blog/agentic-loop-engineering-cover.svg
+++ b/public/images/blog/agentic-loop-engineering-cover.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <linearGradient id="loop" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="50%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Grid pattern -->
+  <g opacity="0.05" stroke="#3b82f6" stroke-width="1">
+    <line x1="0" y1="105" x2="1200" y2="105"/>
+    <line x1="0" y1="210" x2="1200" y2="210"/>
+    <line x1="0" y1="315" x2="1200" y2="315"/>
+    <line x1="0" y1="420" x2="1200" y2="420"/>
+    <line x1="0" y1="525" x2="1200" y2="525"/>
+    <line x1="200" y1="0" x2="200" y2="630"/>
+    <line x1="400" y1="0" x2="400" y2="630"/>
+    <line x1="600" y1="0" x2="600" y2="630"/>
+    <line x1="800" y1="0" x2="800" y2="630"/>
+    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  </g>
+
+  <!-- Central loop -->
+  <g transform="translate(600, 330)">
+    <!-- Loop circle -->
+    <circle cx="0" cy="0" r="180" fill="none" stroke="url(#loop)" stroke-width="3" opacity="0.6" filter="url(#glow)"/>
+    <circle cx="0" cy="0" r="140" fill="none" stroke="url(#loop)" stroke-width="2" opacity="0.3" stroke-dasharray="8 4"/>
+
+    <!-- Nodes around the loop -->
+    <!-- Plan -->
+    <g transform="translate(0, -180)">
+      <circle cx="0" cy="0" r="38" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" fill="#3b82f6" font-family="monospace" font-size="11" font-weight="bold">PLAN</text>
+    </g>
+
+    <!-- Execute -->
+    <g transform="translate(156, -90)">
+      <circle cx="0" cy="0" r="38" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="10" font-weight="bold">EXEC</text>
+    </g>
+
+    <!-- Verify -->
+    <g transform="translate(156, 90)">
+      <circle cx="0" cy="0" r="38" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" fill="#f59e0b" font-family="monospace" font-size="10" font-weight="bold">TEST</text>
+    </g>
+
+    <!-- Learn -->
+    <g transform="translate(0, 180)">
+      <circle cx="0" cy="0" r="38" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" fill="#8b5cf6" font-family="monospace" font-size="10" font-weight="bold">LEARN</text>
+    </g>
+
+    <!-- Deploy -->
+    <g transform="translate(-156, 90)">
+      <circle cx="0" cy="0" r="38" fill="#1e293b" stroke="#06b6d4" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" fill="#06b6d4" font-family="monospace" font-size="9" font-weight="bold">DEPLOY</text>
+    </g>
+
+    <!-- Spec -->
+    <g transform="translate(-156, -90)">
+      <circle cx="0" cy="0" r="38" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" fill="#ef4444" font-family="monospace" font-size="10" font-weight="bold">SPEC</text>
+    </g>
+
+    <!-- Arrows -->
+    <g fill="none" stroke-width="2.5" opacity="0.7">
+      <path d="M 30,-155 Q 90,-120 130,-100" stroke="#3b82f6"/>
+      <path d="M 165,-55 Q 185,0 165,55" stroke="#10b981"/>
+      <path d="M 130,100 Q 90,135 30,155" stroke="#f59e0b"/>
+      <path d="M -30,155 Q -90,135 -130,100" stroke="#8b5cf6"/>
+      <path d="M -165,55 Q -185,0 -165,-55" stroke="#06b6d4"/>
+      <path d="M -130,-100 Q -90,-120 -30,-155" stroke="#ef4444"/>
+    </g>
+
+    <!-- Center -->
+    <circle cx="0" cy="0" r="50" fill="#0f172a" stroke="#1e293b" stroke-width="2"/>
+    <text x="0" y="-5" text-anchor="middle" fill="#64748b" font-family="sans-serif" font-size="10">AGENT</text>
+    <text x="0" y="12" text-anchor="middle" fill="#64748b" font-family="sans-serif" font-size="10">LOOP</text>
+  </g>
+
+  <!-- Title -->
+  <text x="80" y="80" fill="#f1f5f9" font-family="sans-serif" font-size="32" font-weight="bold">Agentic Loop Engineering</text>
+  <text x="80" y="110" fill="#64748b" font-family="sans-serif" font-size="16">SDD · SPDD · BMAD · Harness · Loop Engineering</text>
+
+  <!-- Bottom labels -->
+  <text x="80" y="560" fill="#3b82f6" font-family="monospace" font-size="12">hermes-agent</text>
+  <text x="200" y="560" fill="#64748b" font-family="monospace" font-size="12">+ kanban + github</text>
+  <text x="350" y="560" fill="#64748b" font-family="monospace" font-size="12">| MiniMax M3 · GLM 5.2</text>
+
+  <!-- Tech icons (simplified) -->
+  <g transform="translate(1050, 540)" opacity="0.4">
+    <rect x="-30" y="-15" width="60" height="30" rx="4" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+    <text x="0" y="5" text-anchor="middle" fill="#3b82f6" font-family="monospace" font-size="9">CI/CD</text>
+  </g>
+</svg>

--- a/public/images/blog/agentic-techniques-comparison.svg
+++ b/public/images/blog/agentic-techniques-comparison.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 420" width="1000" height="420">
+  <defs>
+    <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1000" height="420" fill="url(#bg3)" rx="12"/>
+
+  <!-- Title -->
+  <text x="500" y="35" text-anchor="middle" fill="#f1f5f9" font-family="sans-serif" font-size="18" font-weight="bold">Comparison: SDD vs SPDD vs BMAD vs Harness+Loop</text>
+
+  <!-- Column headers -->
+  <g font-family="monospace" font-size="11" font-weight="bold" text-anchor="middle">
+    <text x="140" y="65" fill="#ef4444">SDD</text>
+    <text x="340" y="65" fill="#f59e0b">SPDD</text>
+    <text x="540" y="65" fill="#8b5cf6">BMAD</text>
+    <text x="780" y="65" fill="#10b981">HARNESS + LOOP</text>
+  </g>
+
+  <!-- Subtitle -->
+  <g font-family="sans-serif" font-size="9" text-anchor="middle" fill="#64748b">
+    <text x="140" y="80">Spec-Driven Dev</text>
+    <text x="340" y="80">Spec-Driven Product Dev</text>
+    <text x="540" y="80">Agile AI-Driven Dev</text>
+    <text x="780" y="80">Autonomous Agent Loop</text>
+  </g>
+
+  <!-- Row dividers -->
+  <g stroke="#374151" stroke-width="1">
+    <line x1="30" y1="95" x2="970" y2="95"/>
+    <line x1="30" y1="155" x2="970" y2="155"/>
+    <line x1="30" y1="215" x2="970" y2="215"/>
+    <line x1="30" y1="275" x2="970" y2="275"/>
+    <line x1="30" y1="335" x2="970" y2="335"/>
+  </g>
+
+  <!-- Column dividers -->
+  <g stroke="#374151" stroke-width="1">
+    <line x1="240" y1="95" x2="240" y2="395"/>
+    <line x1="440" y1="95" x2="440" y2="395"/>
+    <line x1="640" y1="95" x2="640" y2="395"/>
+  </g>
+
+  <!-- Row labels -->
+  <g font-family="monospace" font-size="9" fill="#64748b">
+    <text x="35" y="125">Spec First</text>
+    <text x="35" y="185">Agents</text>
+    <text x="35" y="245">Product Focus</text>
+    <text x="35" y="305">Autonomy</text>
+    <text x="35" y="365">Verification</text>
+  </g>
+
+  <!-- Data -->
+  <g font-family="sans-serif" font-size="10" fill="#cbd5e1" text-anchor="middle">
+    <text x="140" y="125">✓ Spec → Code</text>
+    <text x="340" y="125">✓ Spec → Product</text>
+    <text x="540" y="125">✓ PRD → Arch → Code</text>
+    <text x="780" y="125">✓ Plan → Spec → Code → Verify</text>
+
+    <text x="140" y="185">Single agent</text>
+    <text x="340" y="185">Multi-agent</text>
+    <text x="540" y="185">12+ personas</text>
+    <text x="780" y="185">Orchestrator + workers</text>
+
+    <text x="140" y="245">Low</text>
+    <text x="340" y="245">Medium</text>
+    <text x="540" y="245">High (PM, UX, Dev)</text>
+    <text x="780" y="245">Full lifecycle</text>
+
+    <text x="140" y="305">Manual trigger</text>
+    <text x="340" y="305">Workflow-guided</text>
+    <text x="540" y="305">Workflow-guided</text>
+    <text x="780" y="305">Fully autonomous</text>
+
+    <text x="140" y="365">Tests</text>
+    <text x="340" y="365">Tests + Review</text>
+    <text x="540" y="365">Review + Retro</text>
+    <text x="780" y="365">Unit + E2E + Load + CI/CD</text>
+  </g>
+</svg>

--- a/src/content/blog/agentic-loop-engineering.en.md
+++ b/src/content/blog/agentic-loop-engineering.en.md
@@ -247,6 +247,18 @@ We use both models in complementary roles:
 
 The result: a full agentic loop — planning, implementation, review, and deployment — costs **under $1 per feature** on average. That is cheap enough to run multiple iterations, try alternative approaches, and still come out ahead.
 
+### Going further: MiniMax subscription plans
+
+For teams that run agent loops constantly — daily deployments, automated routines, continuous integration — pay-per-token pricing still adds up. MiniMax offers **monthly subscription plans** that make this dramatically cheaper:
+
+| Plan | Price/month | Tokens/month | Effective cost per 1M tokens |
+|------|-------------|-------------|------------------------------|
+| Starter | ~$20 | ~1B | ~$0.02/M |
+| Pro | ~$50 | ~5B | ~$0.01/M |
+| Max | ~$110 | ~12B | ~$0.009/M |
+
+At the Max tier, the effective cost drops to roughly **$0.009 per million tokens** — that is **30x cheaper** than the pay-per-token price on OpenRouter, and **300x+ cheaper** than frontier models. For our use case, where we run agentic loops daily across multiple projects, the subscription pays for itself within the first few days of the month. When your harness is shipping features autonomously and the marginal cost of each additional iteration approaches zero, the economics of automation compound in your favor.
+
 ---
 
 ## Case studies: oficina.brenon.cloud and ai.brenon.cloud
@@ -411,6 +423,19 @@ Here is what we are exploring next:
 The promise of loop engineering is not that agents replace engineers. It is that agents handle the mechanical work — the implementation, the testing, the deployment — so that engineers can focus on the parts that matter: the architecture, the product vision, and the human context that no model can replicate.
 
 That is the loop we are building. And it is just getting started.
+
+---
+
+## Coming next: beyond code — Hermes as a daily autonomous companion
+
+The same harness that ships software is also the backbone of our daily automation routine. In the next post, we will dive into how we use Hermes Agent beyond software engineering:
+
+- **Investment news aggregation** — Hermes runs on a cron schedule, pulls market data, summarizes key movements, and delivers a personalized briefing every morning before the market opens
+- **Smart home control** — connected to our Home Assistant setup, Hermes controls lights, sensors, and devices through natural language commands and automated routines triggered by time, events, or conditions
+- **Podcast production** — Hermes researches topics, writes scripts, generates audio via TTS, and produces complete podcast episodes autonomously — from idea to publishable audio file
+- **Day-to-day task automation** — from managing reminders and calendar events to monitoring infrastructure and sending alerts, Hermes runs dozens of small automations that compound into hours of saved time every week
+
+When the marginal cost of an agent run approaches zero — thanks to subscription pricing on models like MiniMax M3 — the question stops being "can I afford to automate this?" and becomes "what *can't* I automate?" That is the world we are building toward, and the next post will show it in practice.
 
 ---
 

--- a/src/content/blog/agentic-loop-engineering.en.md
+++ b/src/content/blog/agentic-loop-engineering.en.md
@@ -1,0 +1,429 @@
+---
+title: Agentic Loop Engineering — How AI Agents Are Rewriting Software Delivery
+description: A deep dive into SDD, SPDD, BMAD, harness architecture, and loop engineering — and how we use Hermes, Kanban, GitHub, MiniMax M3, and GLM 5.2 to ship software autonomously.
+date: 2026-07-15
+author: Brenon Araujo
+tags: [ai, agentic, loop-engineering, hermes, llm, minimax, glm, ci-cd, autonomous-agents]
+cover: /images/blog/agentic-loop-engineering-cover.svg
+coverFallback: /images/blog/agentic-loop-engineering-cover.svg
+---
+
+# Agentic Loop Engineering — How AI Agents Are Rewriting Software Delivery
+
+Software development is undergoing a shift that is deeper than the move from waterfall to agile, or from on-prem to cloud. AI agents are no longer just autocomplete on steroids — they are becoming autonomous workers that plan, code, test, deploy, and learn in continuous loops. The question is no longer *if* agents will write software, but *how* we orchestrate them to produce results we can trust.
+
+This article is a field report from the front lines. We cover the main agentic development techniques — **SDD**, **SPDD**, **BMAD**, **harness architecture**, and **loop engineering** — explain how they differ, and show how we built a working harness using **Hermes Agent**, its native **Kanban** plugin, and **GitHub** integration. We also talk about the economics of running token-heavy agent loops on models like **MiniMax M3** and **GLM 5.2** — which cost a fraction of frontier models while delivering production-grade results. Finally, we share what worked, what broke, and the pitfalls we hit along the way while shipping real projects like **oficina.brenon.cloud** and **ai.brenon.cloud**.
+
+---
+
+## The landscape: five techniques, one goal
+
+Before diving into implementation, let's map the territory. Five approaches dominate agentic software development today. They are not mutually exclusive — in practice, the best harnesses borrow from all of them.
+
+### 1. SDD — Spec-Driven Development
+
+**SDD** (Spec-Driven Development) is the simplest and most foundational approach: you write a detailed specification before any code is written, and the agent implements exactly what the spec says. The spec is the contract. The agent is the builder.
+
+The core idea is that ambiguity is the enemy of autonomous coding. A human developer can ask clarifying questions when a spec is vague. An AI agent cannot — or at least, it should not have to. The more precise the specification, the closer the output gets to what you intended.
+
+SDD works well for bounded tasks: a single API endpoint, a React component, a CLI tool. It struggles when the problem space is large or poorly defined, because the spec itself becomes the bottleneck — you spend more time writing specs than code.
+
+**Key characteristics:**
+
+- Single agent, single task
+- Spec is written by a human, consumed by an agent
+- Linear flow: Spec → Code → Test
+- Minimal orchestration needed
+- Best for: bug fixes, single features, well-scoped tasks
+
+### 2. SPDD — Spec-Driven Product Development
+
+**SPDD** extends SDD to the full product lifecycle. Instead of a single spec, you produce a chain of documents: a product brief, a PRD (Product Requirements Document), architecture decisions, UX flows, and story breakdowns — all before implementation begins. Multiple agents can be involved, each specialized in a phase.
+
+The philosophy is that products fail not because the code is wrong, but because the *why* was never articulated. By driving product thinking through structured specs, agents have the context they need to make decisions that align with the product vision — not just the immediate ticket.
+
+SPDD is heavier than SDD, but it produces dramatically better results for anything larger than a single feature. It is the bridge between "vibes coding" (prompting an agent with a one-liner) and engineering.
+
+**Key characteristics:**
+
+- Multi-agent, multi-phase
+- Document chain: Brief → PRD → Architecture → Stories → Code
+- Agents specialize per phase (PM, Architect, Developer)
+- Medium orchestration
+- Best for: new products, platform features, multi-component work
+
+### 3. BMAD — Breakthrough Method for Agile AI-Driven Development
+
+**BMAD** is the most structured of the agentic methodologies. With over 50,000 stars on GitHub, it provides 12+ specialized agent personas (PM, Architect, Developer, UX Designer, Analyst, and more), 34+ guided workflows, and a scale-adaptive intelligence system that adjusts planning depth based on project complexity.
+
+BMAD's key innovation is **scale-domain-adaptive planning**. A bug fix gets a lightweight quick-flow path. An enterprise platform gets the full PRD + Architecture + Security + DevOps treatment. The framework auto-detects which track to use based on project size and complexity, rather than forcing every task through the same heavy process.
+
+The phases are:
+
+1. **Analysis** — brainstorming, research, product brief, PRFAQ
+2. **Planning** — PRD creation, UX design, architecture
+3. **Solutioning** — architecture spine, epic and story creation, implementation readiness check
+4. **Implementation** — sprint planning, story-by-story development, code review, retrospectives
+
+BMAD also introduces "Party Mode" — bringing multiple agent personas into one session to collaborate and discuss, simulating a real team meeting.
+
+**Key characteristics:**
+
+- 12+ specialized agent personas
+- 34+ guided workflows across 4 phases
+- Scale-adaptive: Quick Flow, BMad Method, Enterprise tracks
+- Party Mode for multi-agent collaboration
+- Best for: teams that want a full methodology, not just a tool
+
+### 4. Harness Architecture
+
+A **harness** is the orchestration layer that ties agents, tools, and verification together into a repeatable pipeline. Think of it as CI/CD for AI agents: instead of just letting an agent write code and hoping for the best, the harness defines how agents are spawned, how work is decomposed, how tasks are assigned, how results are verified, and how feedback loops back into the next iteration.
+
+The key components of a harness are:
+
+- **Orchestrator** — the parent session that decomposes work, manages the task queue, and aggregates results
+- **Worker agents** — isolated child sessions that execute individual tasks with their own context windows
+- **Task board** — a durable queue that tracks state, dependencies, and assignment
+- **Verification layer** — automated tests, code review, and quality gates that decide whether output is acceptable
+- **Feedback loop** — results from verification feed back into planning for the next cycle
+
+A harness without verification is just a script runner. The verification layer is what makes it *engineering* instead of *vibes coding*.
+
+### 5. Loop Engineering
+
+**Loop engineering** is the paradigm that emerges when you combine all of the above into a continuous cycle. Instead of treating each agent run as a one-shot task, loop engineering puts the agent in a feedback loop:
+
+1. **Plan** — decompose the goal into tasks
+2. **Execute** — agents implement the tasks
+3. **Verify** — run tests, code review, performance checks
+4. **Learn** — capture what worked and what failed as reusable skills
+5. **Deploy** — ship the verified output through CI/CD
+6. **Repeat** — the next iteration starts with accumulated knowledge
+
+The loop is what makes the system *improve* over time. Without it, every task starts from scratch. With it, the agent framework gets better at your specific codebase, conventions, and patterns — because it remembers.
+
+---
+
+## Comparison at a glance
+
+![Technique Comparison](/images/blog/agentic-techniques-comparison.svg)
+
+| Technique | Spec First | Agent Model | Product Focus | Autonomy | Verification |
+|-----------|-----------|-------------|---------------|----------|-------------|
+| **SDD** | Spec → Code | Single agent | Low | Manual trigger | Tests |
+| **SPDD** | Spec → Product | Multi-agent | Medium | Workflow-guided | Tests + Review |
+| **BMAD** | PRD → Arch → Code | 12+ personas | High | Workflow-guided | Review + Retro |
+| **Harness + Loop** | Plan → Spec → Code → Verify | Orchestrator + workers | Full lifecycle | Fully autonomous | Unit + E2E + Load + CI/CD |
+
+---
+
+## Building the harness: Hermes + Kanban + GitHub
+
+We did not adopt these techniques in the abstract — we built a working harness on top of **Hermes Agent** and its native **Kanban** plugin. Here is how the pieces fit.
+
+![Harness Architecture](/images/blog/agentic-harness-architecture.svg)
+
+### The orchestrator
+
+The parent Hermes session acts as the orchestrator. It receives a goal — "build a blog post system with i18n support" or "create an AI playground with multiple model providers" — and decomposes it into discrete tasks. Each task has:
+
+- A clear goal statement
+- A list of dependencies (which tasks must complete first)
+- An assigned worker (or "unassigned" for the dispatcher to claim)
+
+### The Kanban board
+
+Hermes ships with a native Kanban system backed by SQLite. It is not just a pretty UI — it is a durable, multi-profile work queue that supports:
+
+- **Task creation** with idempotency keys (so re-running a dispatcher does not duplicate tasks)
+- **Dependencies** — task B waits for task A to complete
+- **Assignment** — tasks are assigned to specific Hermes profiles
+- **Blocking** — a task that fails N times is auto-blocked
+- **Heartbeats** — workers ping the board periodically so the dispatcher can detect stale claims
+- **Daemon mode** — the dispatcher runs inside the gateway, reclaiming stale tasks and promoting ready ones automatically
+
+The CLI is straightforward:
+
+```bash
+# Initialize a board
+hermes kanban init --board my-feature
+
+# Create tasks with dependencies
+hermes kanban create --board my-feature \
+  --title "Build API layer" \
+  --idempotency-key "api-layer-v1"
+
+hermes kanban create --board my-feature \
+  --title "Build frontend" \
+  --depends-on "api-layer-v1"
+
+# Link, assign, track
+hermes kanban link --board my-feature \
+  --task frontend --depends-on api-layer-v1
+hermes kanban assign --board my-feature \
+  --task frontend --profile worker-1
+```
+
+### Worker agents via delegate_task
+
+The orchestrator spawns workers using `delegate_task` in batch mode. Each worker is a fully isolated subagent:
+
+- **Separate conversation context** — no context window pollution from the parent
+- **Separate terminal session** — no working directory conflicts
+- **Subset of tools** — workers only see the tools they need, reducing token overhead
+- **Background execution** — workers run in parallel, and their results re-enter the parent conversation when they finish
+
+A typical dispatch looks like this:
+
+```
+delegate_task(tasks=[
+  {goal: "Build REST API for blog posts with CRUD", context: "..."},
+  {goal: "Build Vue components for blog listing and post page", context: "..."},
+  {goal: "Set up i18n with pt-BR and en-US", context: "..."}
+])
+```
+
+Three workers, three isolated contexts, running in parallel. The parent session keeps working — when each worker finishes, its summary re-enters the conversation as a new message.
+
+### GitHub integration
+
+Every worker output flows through GitHub:
+
+1. **Branch** — each task gets its own branch
+2. **Commit** — the worker commits with conventional commit messages (`feat:`, `fix:`, `refactor:`)
+3. **PR** — the worker opens a pull request using `gh pr create`
+4. **CI/CD** — GitHub Actions runs the test suite (unit, e2e, smoke)
+5. **Code review** — the orchestrator or a dedicated reviewer agent reviews the diff
+6. **Merge** — after approval, the PR merges and the next task unblocks
+
+This is not theoretical. We use the `gh` CLI directly from agent sessions:
+
+```bash
+# Worker creates a branch and PR
+git checkout -b feat/blog-i18n
+git add -A && git commit -m "feat: add i18n support for blog posts"
+gh pr create --title "feat: add i18n support for blog posts" \
+  --body "Implements pt-BR and en-US variants for blog content"
+```
+
+The GitHub integration is what makes the loop *verifiable*. An agent can write code, but CI/CD tells you whether it works. The PR is the artifact. The merge is the gate.
+
+---
+
+## The model economics: MiniMax M3 and GLM 5.2
+
+Here is the uncomfortable truth about agentic loops: they are token-hungry. A single feature — from planning to implementation to review — can consume 50,000 to 200,000 tokens across multiple agent turns, tool calls, and context windows. Run that on Claude Sonnet at $3/$15 per million tokens, and a single feature costs $0.50 to $3.00. Ship 50 features and you are looking at $25 to $150 in API costs alone.
+
+That is where models like **MiniMax M3** and **GLM 5.2** change the equation.
+
+### MiniMax M3
+
+MiniMax M3 is a multimodal foundation model with a **1M-token context window**, built on MiniMax Sparse Attention (MSA). MSA replaces full attention with KV-block selection, cutting per-token compute at long context to roughly **1/20 the cost of the previous generation** at 1M tokens.
+
+**Pricing on OpenRouter:** $0.30/M input, $1.20/M output.
+
+That means a 200K-token feature costs roughly **$0.06** in input and **$0.24** in output — **under $0.30 total**. Compare that to $1.50 to $3.00 on a frontier model, and you are looking at a **5–10x cost reduction** with comparable quality for agentic coding tasks.
+
+M3 also ranks in the top 5–6 across multiple benchmark categories on OpenRouter, including Academia (#6), Finance (#3), Health (#5), and Legal (#18). It is not a toy model — it is a production-grade model that happens to be dramatically cheaper.
+
+### GLM 5.2
+
+GLM 5.2 is Z.ai's large-scale reasoning model, also with a **1M-token context window**. It supports reasoning efforts `high` and `xhigh` (mapping to max reasoning), and is specifically tuned for **long-horizon agent workflows, project-level software engineering, and complex multi-step automation**.
+
+**Pricing on OpenRouter:** $0.91/M input, $2.86/M output.
+
+More expensive than M3, but still **3–5x cheaper** than frontier models. GLM 5.2 excels at maintaining engineering context across a full development workflow — from requirements to multi-platform deployment — in a single task. That makes it ideal for the orchestrator role, where it needs to hold the big picture while workers handle individual tasks.
+
+### The combined strategy
+
+We use both models in complementary roles:
+
+| Role | Model | Why |
+|------|-------|-----|
+| **Orchestrator** | GLM 5.2 | Long-context reasoning, maintains project-wide context, strong planning |
+| **Workers** | MiniMax M3 | Cheaper per-token, 1M context, strong coding and tool use |
+| **Code review** | GLM 5.2 | Reasoning depth for diff analysis and quality assessment |
+| **Auxiliary tasks** (vision, compression) | MiniMax M3 | Cost-effective for high-volume, lower-stakes tasks |
+
+The result: a full agentic loop — planning, implementation, review, and deployment — costs **under $1 per feature** on average. That is cheap enough to run multiple iterations, try alternative approaches, and still come out ahead.
+
+---
+
+## Case studies: oficina.brenon.cloud and ai.brenon.cloud
+
+### oficina.brenon.cloud
+
+**Oficina** ("workshop" in Portuguese) is a creative coding playground — a collection of mini-apps, experiments, and tools built with Vue 3 + Vite + Tailwind, deployed on Netlify. It was built almost entirely through agentic loops:
+
+1. **Planning** — the orchestrator decomposed the project into tasks: project scaffold, routing, component library, individual mini-apps, deployment config
+2. **Parallel execution** — 3 workers built independent mini-apps simultaneously, each in an isolated context with its own branch
+3. **Integration** — the orchestrator merged the PRs, resolved conflicts, and ran the full test suite
+4. **Deployment** — Netlify auto-deployed on merge to `main`
+
+The entire project — from empty repo to deployed site — took **one session**. The orchestrator spawned workers, workers opened PRs, CI ran tests, and the orchestrator merged. No manual coding beyond the initial goal statement.
+
+### ai.brenon.cloud
+
+**AI** is an AI playground that lets visitors chat with multiple LLM providers (OpenRouter, MiniMax, Z.ai) from a single interface. It was built using the same harness pattern:
+
+- **Task decomposition**: API layer (model routing, key management), frontend (chat UI, model selector, streaming responses), deployment (Netlify config, environment variables)
+- **Parallel workers**: one built the API, one built the frontend, one wrote tests
+- **Loop verification**: the orchestrator ran the test suite after each PR merge, caught a streaming bug on the first pass, and dispatched a fix task automatically
+- **Result**: a working AI chat playground deployed in under 20 minutes of wall-clock time
+
+Both projects are live and serving real traffic. They are not demos or proofs of concept — they are production deployments that were built by AI agents and verified by CI/CD.
+
+---
+
+## Mermaid: visualizing the agent loop
+
+The Hermes Kanban ecosystem supports Mermaid diagrams natively. Here is the loop engineering cycle as a Mermaid flowchart:
+
+```mermaid
+flowchart TD
+    A[Goal Definition] --> B[Task Decomposition]
+    B --> C[Kanban Board]
+    C --> D1[Worker A: Implementation]
+    C --> D2[Worker B: Implementation]
+    C --> D3[Worker C: Tests]
+    D1 --> E[PR + CI/CD]
+    D2 --> E
+    D3 --> E
+    E --> F{Tests Pass?}
+    F -->|Yes| G[Code Review]
+    F -->|No| H[Auto-fix Task]
+    H --> D1
+    G --> I{Review Approved?}
+    I -->|Yes| J[Merge + Deploy]
+    I -->|No| K[Revise Task]
+    K --> D1
+    J --> L[Learn + Save Skill]
+    L --> A
+```
+
+And here is the harness architecture as a Mermaid sequence diagram:
+
+```mermaid
+sequenceDiagram
+    participant O as Orchestrator (GLM 5.2)
+    participant K as Kanban Board
+    participant W1 as Worker A (M3)
+    participant W2 as Worker B (M3)
+    participant GH as GitHub
+    participant CI as CI/CD
+
+    O->>K: Create tasks + dependencies
+    K->>W1: Claim task (isolated context)
+    K->>W2: Claim task (isolated context)
+    W1->>GH: Create branch + commit + PR
+    W2->>GH: Create branch + commit + PR
+    GH->>CI: Trigger workflow
+    CI-->>GH: Test results
+    GH-->>O: PR status + CI results
+    O->>O: Code review (GLM 5.2)
+    O->>GH: Approve + merge
+    GH->>K: Task complete
+    K-->>O: Next ready task
+```
+
+---
+
+## Pitfalls and lessons learned
+
+Loop engineering is powerful, but it is not magic. Here is what we learned the hard way.
+
+### 1. Partial deliverables matter more than perfection
+
+The biggest mistake is waiting for the "perfect" agent output before shipping. Agents produce better results when they iterate on *real feedback* — from CI, from users, from production — than when you try to get it right on the first pass. Ship partial deliverables, let CI/CD catch regressions, and let the loop refine. This is just continuous delivery, now executed autonomously.
+
+### 2. CI/CD is the safety net, not the agent
+
+Agents will make mistakes. They will introduce bugs, break tests, and sometimes produce code that is technically correct but architecturally wrong. **CI/CD is what makes this safe.** Without a robust test suite — unit tests, e2e tests, smoke tests — you are flying blind. The agent loop without verification is vibes coding with extra steps.
+
+We learned to treat the test suite as the specification. If the tests pass, the code is accepted. If they fail, the loop sends a fix task back to a worker. The tests are the contract.
+
+### 3. Context windows are not infinite
+
+Even with 1M-token context windows, agents lose track of details in long sessions. We learned to:
+
+- **Keep worker tasks small and focused** — a worker should do one thing well, not five things poorly
+- **Use fresh sessions for each major task** — context pollution is real
+- **Pass context explicitly** — do not assume the worker knows anything about the project beyond what you tell it
+- **Use skills for reusable knowledge** — instead of re-explaining conventions every time, save them as a skill that loads automatically
+
+### 4. Load and performance testing in the loop
+
+One of the most interesting recent developments is **automated load and stress testing within the agent loop**. Hermes can now create benchmarks that:
+
+- Spin up a test environment
+- Generate load against the deployed service
+- Measure response times, throughput, and error rates
+- Compare results against baselines from previous runs
+- Automatically create a fix task if performance regresses
+
+This extends the verification layer beyond "does it work?" to "does it work *at scale*?" — which is the difference between a demo and a production system.
+
+The testing pyramid in an agentic loop now looks like:
+
+1. **Unit tests** — fast, isolated, run on every PR
+2. **E2E tests** — integration-level, run after merge
+3. **Smoke tests** — deployed to staging, verify critical paths
+4. **Load tests** — stress the service, measure performance
+5. **Performance benchmarks** — compare against previous runs, detect regressions
+
+Each layer feeds back into the loop. A failing load test creates a task. The task goes to a worker. The worker fixes it. CI verifies. The loop continues.
+
+### 5. The autonomy paradox
+
+The more autonomous the system becomes, the more important human review gates are. We found that fully autonomous loops work great for well-understood patterns (CRUD APIs, UI components, test suites) but need human checkpoints for:
+
+- Architecture decisions that affect multiple components
+- Security-sensitive changes (auth, secrets, network)
+- Breaking changes to public APIs
+- Performance trade-offs that require business context
+
+The harness supports this naturally — the orchestrator can flag a PR for human review instead of auto-merging. The key is knowing *when* to escalate.
+
+### 6. Cost monitoring is non-negotiable
+
+With token-hungry loops, costs can spiral if you are not watching. We monitor:
+
+- **Per-task token consumption** — which tasks are expensive and why
+- **Per-model cost breakdown** — M3 vs GLM 5.2 spending ratio
+- **Retry rate** — how often tasks fail and need re-dispatch
+- **Idle worker time** — workers that claimed tasks but are not making progress
+
+Hermes provides built-in usage analytics (`hermes insights`) that track these metrics. A well-tuned harness should cost under $1 per feature. If it costs more, something is wrong — usually a worker is stuck in a loop, or the task decomposition is too granular.
+
+---
+
+## What is next
+
+We are still early in the loop engineering journey. The current frontier is not better models — it is better orchestration. The models are already good enough. What separates a toy demo from a production system is the harness around them: the task decomposition, the verification gates, the feedback loops, and the skill accumulation.
+
+Here is what we are exploring next:
+
+- **Cross-project skill transfer** — when an agent learns a pattern in one project, can it apply it to another?
+- **Multi-model orchestration** — different models for different task types (coding, review, planning, testing)
+- **Autonomous incident response** — when production breaks, can the loop detect, diagnose, and fix without human intervention?
+- **Continuous architecture validation** — not just "does the code work?" but "does the architecture still make sense?"
+
+The promise of loop engineering is not that agents replace engineers. It is that agents handle the mechanical work — the implementation, the testing, the deployment — so that engineers can focus on the parts that matter: the architecture, the product vision, and the human context that no model can replicate.
+
+That is the loop we are building. And it is just getting started.
+
+---
+
+## References and Useful Links
+
+- **[Hermes Agent](https://hermes-agent.nousresearch.com/docs/)** — Open-source AI agent framework by Nous Research. The foundation of our harness.
+- **[Hermes Kanban Documentation](https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban)** — Native multi-agent work queue with SQLite backing, dispatcher, and worker profiles.
+- **[BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD)** — Breakthrough Method for Agile AI-Driven Development. 50k+ stars, 12+ agent personas, 34+ workflows.
+- **[BMAD Method Docs](https://docs.bmad-method.org)** — Complete documentation including tutorials, how-to guides, and reference.
+- **[MiniMax M3 on OpenRouter](https://openrouter.ai/minimax/minimax-m3)** — 1M context window, $0.30/$1.20 per million tokens, multimodal.
+- **[GLM 5.2 on OpenRouter](https://openrouter.ai/z-ai/glm-5.2)** — 1M context window, $0.91/$2.86 per million tokens, long-horizon reasoning.
+- **[OpenRouter Models](https://openrouter.ai/models)** — Compare pricing, context windows, and benchmarks across all available models.
+- **[GitHub CLI (gh)](https://cli.github.com/)** — Command-line tool for GitHub, used by agents for PR creation, review, and merge.
+- **[oficina.brenon.cloud](https://oficina.brenon.cloud)** — Creative coding playground built entirely through agentic loops.
+- **[ai.brenon.cloud](https://ai.brenon.cloud)** — AI chat playground with multi-provider support, built through agentic loops.
+- **[brenon.cloud](https://brenon.cloud)** — The home cloud blog and portfolio where this article is published.

--- a/src/content/blog/agentic-loop-engineering.en.md
+++ b/src/content/blog/agentic-loop-engineering.en.md
@@ -287,9 +287,9 @@ Both projects are live and serving real traffic. They are not demos or proofs of
 
 ---
 
-## Mermaid: visualizing the agent loop
+## Visualizing the agent loop
 
-The Hermes Kanban ecosystem supports Mermaid diagrams natively. Here is the loop engineering cycle as a Mermaid flowchart:
+The loop engineering cycle as a flowchart:
 
 ```mermaid
 flowchart TD
@@ -313,7 +313,7 @@ flowchart TD
     L --> A
 ```
 
-And here is the harness architecture as a Mermaid sequence diagram:
+And here is the harness architecture as a sequence diagram:
 
 ```mermaid
 sequenceDiagram

--- a/src/content/blog/agentic-loop-engineering.en.md
+++ b/src/content/blog/agentic-loop-engineering.en.md
@@ -119,7 +119,9 @@ The loop is what makes the system *improve* over time. Without it, every task st
 
 ## Building the harness: Hermes + Kanban + GitHub
 
-We did not adopt these techniques in the abstract — we built a working harness on top of **Hermes Agent** and its native **Kanban** plugin. Here is how the pieces fit.
+Before diving into the architecture, a quick introduction to **Hermes Agent**. Hermes is an open-source AI agent framework created by Nous Research that runs in your terminal, a native desktop app, messaging platforms, and IDEs. It is provider-agnostic — you can swap between OpenRouter, Anthropic, OpenAI, MiniMax, Z.ai, and 20+ other providers mid-workflow without changing anything else. It learns from experience by saving reusable procedures as skills, remembers who you are and your preferences across sessions, and can run on Telegram, Discord, Slack, WhatsApp, and a dozen more platforms with full tool access — not just chat.
+
+We did not adopt agentic techniques in the abstract — we built a working harness on top of Hermes and its native **Kanban** plugin. Here is how the pieces fit.
 
 ![Harness Architecture](/images/blog/agentic-harness-architecture.svg)
 
@@ -257,7 +259,19 @@ For teams that run agent loops constantly — daily deployments, automated routi
 | Pro | ~$50 | ~5B | ~$0.01/M |
 | Max | ~$110 | ~12B | ~$0.009/M |
 
-At the Max tier, the effective cost drops to roughly **$0.009 per million tokens** — that is **30x cheaper** than the pay-per-token price on OpenRouter, and **300x+ cheaper** than frontier models. For our use case, where we run agentic loops daily across multiple projects, the subscription pays for itself within the first few days of the month. When your harness is shipping features autonomously and the marginal cost of each additional iteration approaches zero, the economics of automation compound in your favor.
+The GitHub integration is what makes the loop *verifiable*. An agent can write code, but CI/CD tells you whether it works. The PR is the artifact. The merge is the gate.
+
+### Discord and Telegram: real-time status reports
+
+One of the most valuable additions to our harness is **event-driven monitoring via Discord and Telegram**. Hermes has a built-in gateway that connects to both platforms with full tool access — so we configured it to send status reports as work progresses:
+
+- **Task claimed** — when a worker picks up a task, a message goes to the channel with the task title, assignee, and estimated scope
+- **PR opened** — when a worker opens a PR, the channel gets the PR URL, diff summary, and CI status link
+- **CI result** — when CI passes or fails, the channel gets a green/red notification with logs
+- **Review needed** — when the orchestrator flags a PR for human review, the channel pings with the diff and the reason for escalation
+- **Task completed** — when a task is done and merged, the channel gets a summary of what was shipped
+
+This means we do not have to sit watching the Kanban board. The board comes to us. When something needs attention — a failing test, a review gate, a blocked task — we get a notification on our phone or desktop. We can step in, make a decision, and let the loop continue. This is what makes the harness feel like a *team* rather than a script: it communicates.
 
 ---
 
@@ -265,23 +279,66 @@ At the Max tier, the effective cost drops to roughly **$0.009 per million tokens
 
 ### oficina.brenon.cloud
 
-**Oficina** ("workshop" in Portuguese) is a creative coding playground — a collection of mini-apps, experiments, and tools built with Vue 3 + Vite + Tailwind, deployed on Netlify. It was built almost entirely through agentic loops:
+**Oficina Cloud** is a SaaS ERP for automotive repair shops — not a creative playground, but a full multi-tenant business platform. It handles:
 
-1. **Planning** — the orchestrator decomposed the project into tasks: project scaffold, routing, component library, individual mini-apps, deployment config
-2. **Parallel execution** — 3 workers built independent mini-apps simultaneously, each in an isolated context with its own branch
-3. **Integration** — the orchestrator merged the PRs, resolved conflicts, and ran the full test suite
-4. **Deployment** — Netlify auto-deployed on merge to `main`
+- **Clients and vehicles** — a searchable database where shops register customers and their vehicles, with history that follows the vehicle even when it changes shops
+- **Service orders (OS)** — full work-order management with service items, parts, automatic stock deduction, and total value calculation
+- **Stock and catalog** — parts inventory with manual entry and automatic deduction when a service order is completed
+- **Shared vehicle history** — the vehicle is a platform-level entity. Every shop that serviced it sees the consolidated history, maintaining information integrity and access control across shops
+- **Multi-tenant architecture** — each shop gets its own dedicated database schema, with total isolation between tenants and zero data leakage
 
-The entire project — from empty repo to deployed site — took **one session**. The orchestrator spawned workers, workers opened PRs, CI ran tests, and the orchestrator merged. No manual coding beyond the initial goal statement.
+The architecture is a true SaaS multi-tenant system with a dedicated backend and database. Each tenant (shop) has isolated data, but the vehicle entity is shared at the platform level — so when a car moves from one shop to another, the new shop sees the full service history from all previous shops, with proper access controls. This is a design that required careful thinking about data ownership, tenant isolation, and cross-tenant read access for the shared vehicle entity.
+
+The multi-tenant architecture can be visualized as:
+
+```mermaid
+flowchart TB
+    subgraph Platform
+        DB[Shared Vehicle Registry]
+    end
+    subgraph Tenant A - Shop 1
+        S1[Shop 1 Schema]
+        S1 --- DB
+    end
+    subgraph Tenant B - Shop 2
+        S2[Shop 2 Schema]
+        S2 --- DB
+    end
+    subgraph Tenant C - Shop 3
+        S3[Shop 3 Schema]
+        S3 --- DB
+    end
+    S1 -.->|reads vehicle history| DB
+    S2 -.->|reads vehicle history| DB
+    S3 -.->|reads vehicle history| DB
+```
+
+Built through agentic loops:
+
+1. **Planning** — the orchestrator decomposed the project into tasks: backend scaffold, multi-tenant database layer, vehicle registry, service orders, stock management, frontend, deployment config
+2. **Parallel execution** — workers built independent modules simultaneously: one on the multi-tenant schema isolation, one on the service orders CRUD, one on the frontend
+3. **Integration** — the orchestrator merged the PRs, resolved cross-module conflicts (especially around the shared vehicle entity), and ran the full test suite
+4. **Deployment** — Netlify auto-deployed the frontend on merge to `main`
+
+The entire project — from empty repo to deployed SaaS — was built in **one agentic session**. The orchestrator spawned workers, workers opened PRs, CI ran tests, and the orchestrator merged. No manual coding beyond the initial goal statement and architecture decision.
 
 ### ai.brenon.cloud
 
-**AI** is an AI playground that lets visitors chat with multiple LLM providers (OpenRouter, MiniMax, Z.ai) from a single interface. It was built using the same harness pattern:
+**brnnaicloud** is a unified AI API gateway — a platform that lets developers access multiple LLM providers (GPT-4o, Claude 3.5 Sonnet, Gemini 1.5, Llama 3.1, Mistral, and more) through a single OpenAI-compatible endpoint. Key features:
 
-- **Task decomposition**: API layer (model routing, key management), frontend (chat UI, model selector, streaming responses), deployment (Netlify config, environment variables)
+- **One API** — OpenAI-compatible endpoint; migrate by changing the base URL
+- **Real-time cost tracking** — see spend update the moment a request lands
+- **Per-key isolation** — mint separate keys per app, per environment, per team
+- **Transparent pricing** — per-token rates with no markup on provider prices
+- **Usage analytics** — breakdowns by model, by day, by key
+- **BYOK friendly** — bring your own provider keys, route through the platform
+
+Built using the same harness pattern:
+
+- **Task decomposition**: API layer (model routing, key management, usage tracking), frontend (chat UI, model selector, pricing page), deployment (Netlify config, environment variables)
 - **Parallel workers**: one built the API, one built the frontend, one wrote tests
 - **Loop verification**: the orchestrator ran the test suite after each PR merge, caught a streaming bug on the first pass, and dispatched a fix task automatically
-- **Result**: a working AI chat playground deployed in under 20 minutes of wall-clock time
+- **Result**: a working AI API gateway deployed in under 20 minutes of wall-clock time
 
 Both projects are live and serving real traffic. They are not demos or proofs of concept — they are production deployments that were built by AI agents and verified by CI/CD.
 

--- a/src/content/blog/agentic-loop-engineering.pt.md
+++ b/src/content/blog/agentic-loop-engineering.pt.md
@@ -247,6 +247,18 @@ Usamos ambos os modelos em papéis complementares:
 
 O resultado: um loop agentic completo — planejamento, implementação, review e deployment — custa **menos de $1 por feature** em média. Isso é barato o suficiente para rodar múltiplas iterações, tentar abordagens alternativas, e ainda sair na frente.
 
+### Indo além: planos de assinatura do MiniMax
+
+Para times que rodam loops de agentes constantemente — deployments diários, rotinas automatizadas, integração contínua — o preço pay-per-token ainda acumula. O MiniMax oferece **planos de assinatura mensal** que tornam isso dramaticamente mais barato:
+
+| Plano | Preço/mês | Tokens/mês | Custo efetivo por 1M tokens |
+|-------|-----------|------------|------------------------------|
+| Starter | ~$20 | ~1B | ~$0.02/M |
+| Pro | ~$50 | ~5B | ~$0.01/M |
+| Max | ~$110 | ~12B | ~$0.009/M |
+
+No tier Max, o custo efetivo cai para aproximadamente **$0.009 por milhão de tokens** — isso é **30x mais barato** que o preço pay-per-token no OpenRouter, e **300x+ mais barato** que modelos frontier. Para o nosso caso de uso, onde rodamos loops agentic diariamente across múltiplos projetos, a assinatura se paga nos primeiros dias do mês. Quando seu harness está shipping features autonomamente e o custo marginal de cada iteração adicional se aproxima de zero, a economia da automação compõe a seu favor.
+
 ---
 
 ## Casos de estudo: oficina.brenon.cloud e ai.brenon.cloud
@@ -411,6 +423,19 @@ Aqui está o que estamos explorando a seguir:
 A promessa do loop engineering não é que agentes substituam engenheiros. É que agentes lidem com o trabalho mecânico — a implementação, os testes, o deployment — para que engenheiros possam focar nas partes que importam: a arquitetura, a visão de produto, e o contexto humano que nenhum modelo consegue replicar.
 
 Esse é o loop que estamos construindo. E está só começando.
+
+---
+
+## O que vem a seguir: além do código — Hermes como companheiro autônomo do dia a dia
+
+O mesmo harness que entrega software também é a espinha dorsal da nossa rotina de automação diária. No próximo post, vamos mergulhar em como usamos o Hermes Agent além da engenharia de software:
+
+- **Agregação de news de investimentos** — o Hermes roda num cron schedule, puxa dados de mercado, sumariza movimentos chave, e entrega um briefing personalizado toda manhã antes da bolsa abrir
+- **Controle de smart home** — conectado ao nosso Home Assistant, o Hermes controla luzes, sensores e dispositivos através de comandos em linguagem natural e rotinas automatizadas disparadas por tempo, eventos ou condições
+- **Produção de podcast** — o Hermes pesquisa tópicos, escreve roteiros, gera áudio via TTS, e produz episódios completos de podcast autonomamente — da ideia ao arquivo de áudio publicável
+- **Automação de tarefas do dia a dia** — de gerenciar lembretes e eventos de calendário a monitorar infraestrutura e enviar alertas, o Hermes roda dezenas de pequenas automações que se acumulam em horas economizadas toda semana
+
+Quando o custo marginal de uma execução de agente se aproxima de zero — graças ao preço de assinatura em modelos como o MiniMax M3 — a pergunta deixa de ser "consigo pagar para automatizar isso?" e se torna "o que eu *não consigo* automatizar?" Esse é o mundo que estamos construindo, e o próximo post vai mostrar isso na prática.
 
 ---
 

--- a/src/content/blog/agentic-loop-engineering.pt.md
+++ b/src/content/blog/agentic-loop-engineering.pt.md
@@ -119,7 +119,9 @@ O loop é o que faz o sistema *melhorar* com o tempo. Sem ele, toda tarefa come�
 
 ## Construindo o harness: Hermes + Kanban + GitHub
 
-Não adotamos essas técnicas no abstrato — construímos um harness funcional em cima do **Hermes Agent** e seu plugin nativo de **Kanban**. Veja como as peças se encaixam.
+Antes de mergulhar na arquitetura, uma rápida introdução ao **Hermes Agent**. O Hermes é um framework de agente de IA open-source criado pela Nous Research que roda no terminal, num app desktop nativo, em plataformas de mensageria e em IDEs. É provider-agnostic — você pode alternar entre OpenRouter, Anthropic, OpenAI, MiniMax, Z.ai e 20+ outros providers no meio de um workflow sem mudar mais nada. Ele aprende com a experiência salvando procedimentos reutilizáveis como skills, lembra de quem você é e das suas preferências across sessões, e pode rodar no Telegram, Discord, Slack, WhatsApp e mais uma dúzia de plataformas com acesso total a ferramentas — não apenas chat.
+
+Não adotamos técnicas agentic no abstrato — construímos um harness funcional em cima do Hermes e seu plugin nativo de **Kanban**. Veja como as peças se encaixam.
 
 ![Arquitetura do Harness](/images/blog/agentic-harness-architecture.svg)
 
@@ -257,7 +259,19 @@ Para times que rodam loops de agentes constantemente — deployments diários, r
 | Pro | ~$50 | ~5B | ~$0.01/M |
 | Max | ~$110 | ~12B | ~$0.009/M |
 
-No tier Max, o custo efetivo cai para aproximadamente **$0.009 por milhão de tokens** — isso é **30x mais barato** que o preço pay-per-token no OpenRouter, e **300x+ mais barato** que modelos frontier. Para o nosso caso de uso, onde rodamos loops agentic diariamente across múltiplos projetos, a assinatura se paga nos primeiros dias do mês. Quando seu harness está shipping features autonomamente e o custo marginal de cada iteração adicional se aproxima de zero, a economia da automação compõe a seu favor.
+A integração com GitHub é o que torna o loop *verificável*. Um agente pode escrever código, mas CI/CD diz se funciona. O PR é o artefato. O merge é o portão.
+
+### Discord e Telegram: relatórios de status em tempo real
+
+Uma das adições mais valiosas ao nosso harness é o **monitoramento event-driven via Discord e Telegram**. O Hermes tem um gateway embutido que se conecta a ambas as plataformas com acesso total a ferramentas — então configuramos ele para enviar relatórios de status conforme o trabalho avança:
+
+- **Tarefa claimed** — quando um worker pega uma tarefa, uma mensagem vai pro canal com o título da tarefa, assignee e escopo estimado
+- **PR aberto** — quando um worker abre um PR, o canal recebe a URL do PR, sumário do diff e link do CI
+- **Resultado do CI** — quando o CI passa ou falha, o canal recebe uma notificação verde/vermelha com logs
+- **Review necessária** — quando o orquestrador flagge um PR para revisão humana, o canal recebe um ping com o diff e o motivo da escalada
+- **Tarefa concluída** — quando uma tarefa termina e é mergeada, o canal recebe um sumário do que foi entregue
+
+Isso significa que não precisamos ficar vigiando o Kanban board. O board vem até a gente. Quando algo precisa de atenção — um teste falhando, um portão de review, uma tarefa bloqueada — recebemos uma notificação no celular ou desktop. Podemos intervir, tomar uma decisão e deixar o loop continuar. É isso que faz o harness parecer um *time* em vez de um script: ele se comunica.
 
 ---
 
@@ -265,23 +279,66 @@ No tier Max, o custo efetivo cai para aproximadamente **$0.009 por milhão de to
 
 ### oficina.brenon.cloud
 
-**Oficina** é um playground de codificação criativa — uma coleção de mini-apps, experimentos e ferramentas construída com Vue 3 + Vite + Tailwind, deployada no Netlify. Foi construído quase inteiramente através de loops agentic:
+**Oficina Cloud** é um SaaS ERP para oficinas mecânicas — não é um playground criativo, mas uma plataforma de negócios multi-tenant completa. Ele gerencia:
 
-1. **Planejamento** — o orquestrador decompôs o projeto em tarefas: scaffold do projeto, roteamento, biblioteca de componentes, mini-apps individuais, config de deployment
-2. **Execução paralela** — 3 workers construíram mini-apps independentes simultaneamente, cada um num contexto isolado com sua própria branch
-3. **Integração** — o orquestrador mergeou os PRs, resolveu conflitos, e rodou a suíte de testes completa
-4. **Deployment** — Netlify auto-deployou no merge para `main`
+- **Clientes e veículos** — um banco de dados pesquisável onde oficinas cadastram clientes e seus veículos, com histórico que segue o veículo mesmo quando ele troca de oficina
+- **Ordens de serviço (OS)** — gerenciamento completo de work-orders com itens de serviço, peças, baixa automática no estoque e cálculo de valor total
+- **Estoque e catálogo** — inventário de peças com entrada manual e baixa automática quando uma OS é concluída
+- **Histórico compartilhado de veículos** — o veículo é uma entidade de nível plataforma. Toda oficina que o atendeu vê o histórico consolidado, mantendo a integridade das informações e controle de acesso entre oficinas
+- **Arquitetura multi-tenant** — cada oficina tem seu próprio schema dedicado no banco, com isolamento total entre tenants e zero vazamento de dados
 
-O projeto inteiro — de repo vazio a site deployado — levou **uma sessão**. O orquestrador spawn workers, workers abriram PRs, CI rodou testes, e o orquestrador mergeou. Zero codificação manual além do goal statement inicial.
+A arquitetura é um verdadeiro sistema SaaS multi-tenant com backend e banco de dados dedicados. Cada tenant (oficina) tem dados isolados, mas a entidade veículo é compartilhada no nível da plataforma — então quando um carro muda de uma oficina para outra, a nova oficina vê o histórico completo de service de todas as oficinas anteriores, com controles de acesso adequados. Esse é um design que exigiu pensamento cuidadoso sobre propriedade de dados, isolamento de tenant e acesso de leitura cross-tenant para a entidade veículo compartilhada.
+
+A arquitetura multi-tenant pode ser visualizada como:
+
+```mermaid
+flowchart TB
+    subgraph Platform
+        DB[Shared Vehicle Registry]
+    end
+    subgraph Tenant A - Shop 1
+        S1[Shop 1 Schema]
+        S1 --- DB
+    end
+    subgraph Tenant B - Shop 2
+        S2[Shop 2 Schema]
+        S2 --- DB
+    end
+    subgraph Tenant C - Shop 3
+        S3[Shop 3 Schema]
+        S3 --- DB
+    end
+    S1 -.->|reads vehicle history| DB
+    S2 -.->|reads vehicle history| DB
+    S3 -.->|reads vehicle history| DB
+```
+
+Construído através de loops agentic:
+
+1. **Planejamento** — o orquestrador decompôs o projeto em tarefas: scaffold do backend, camada de banco multi-tenant, registro de veículos, ordens de serviço, gerenciamento de estoque, frontend, config de deployment
+2. **Execução paralela** — workers construíram módulos independentes simultaneamente: um no isolamento de schema multi-tenant, um no CRUD de ordens de serviço, um no frontend
+3. **Integração** — o orquestrador mergeou os PRs, resolveu conflitos cross-module (especialmente em torno da entidade veículo compartilhada), e rodou a suíte de testes completa
+4. **Deployment** — Netlify auto-deployou o frontend no merge para `main`
+
+O projeto inteiro — de repo vazio a SaaS deployado — foi construído em **uma sessão agentic**. O orquestrador spawn workers, workers abriram PRs, CI rodou testes, e o orquestrador mergeou. Zero codificação manual além do goal statement inicial e da decisão de arquitetura.
 
 ### ai.brenon.cloud
 
-**AI** é um playground de IA que permite visitantes conversarem com múltiplos providers de LLM (OpenRouter, MiniMax, Z.ai) a partir de uma interface única. Foi construído usando o mesmo padrão de harness:
+**brnnaicloud** é um gateway unificado de API de IA — uma plataforma que permite desenvolvedores acessarem múltiplos providers de LLM (GPT-4o, Claude 3.5 Sonnet, Gemini 1.5, Llama 3.1, Mistral, e mais) através de um único endpoint OpenAI-compatible. Features principais:
 
-- **Decomposição de tarefas**: camada de API (roteamento de modelo, gerenciamento de chaves), frontend (UI de chat, seletor de modelo, respostas streaming), deployment (config do Netlify, variáveis de ambiente)
+- **Uma API** — endpoint OpenAI-compatible; migre mudando a base URL
+- **Tracking de custo em tempo real** — veja o gasto atualizar no momento que a requisição chega
+- **Isolamento por chave** — crie chaves separadas por app, por ambiente, por time
+- **Preço transparente** — taxas per-token sem markup no preço do provider
+- **Analytics de uso** — breakdowns por modelo, por dia, por chave
+- **BYOK friendly** — traga suas próprias chaves de provider, roteie pela plataforma
+
+Construído usando o mesmo padrão de harness:
+
+- **Decomposição de tarefas**: camada de API (roteamento de modelo, gerenciamento de chaves, tracking de uso), frontend (UI de chat, seletor de modelo, página de preços), deployment (config do Netlify, variáveis de ambiente)
 - **Workers paralelos**: um construiu a API, um construiu o frontend, um escreveu testes
 - **Verificação em loop**: o orquestrador rodou a suíte de testes depois de cada merge de PR, pegou um bug de streaming na primeira passada, e dispatchou uma tarefa de fix automaticamente
-- **Resultado**: um playground de chat de IA funcionando e deployado em menos de 20 minutos de wall-clock time
+- **Resultado**: um gateway de API de IA funcionando e deployado em menos de 20 minutos de wall-clock time
 
 Ambos os projetos estão no ar e servindo tráfego real. Não são demos ou provas de conceito — são deployments de produção que foram construídos por agentes de IA e verificados por CI/CD.
 

--- a/src/content/blog/agentic-loop-engineering.pt.md
+++ b/src/content/blog/agentic-loop-engineering.pt.md
@@ -287,9 +287,9 @@ Ambos os projetos estão no ar e servindo tráfego real. Não são demos ou prov
 
 ---
 
-## Mermaid: visualizando o loop do agente
+## Visualizando o loop do agente
 
-O ecossistema Hermes Kanban suporta diagramas Mermaid nativamente. Aqui está o ciclo de loop engineering como um flowchart:
+O ciclo de loop engineering como um flowchart:
 
 ```mermaid
 flowchart TD

--- a/src/content/blog/agentic-loop-engineering.pt.md
+++ b/src/content/blog/agentic-loop-engineering.pt.md
@@ -1,0 +1,429 @@
+---
+title: Loop Engineering Agentico — Como Agentes de IA Estão Reescrevendo a Entrega de Software
+description: Um mergulho profundo em SDD, SPDD, BMAD, arquitetura de harness e loop engineering — e como usamos Hermes, Kanban, GitHub, MiniMax M3 e GLM 5.2 para entregar software de forma autônoma.
+date: 2026-07-15
+author: Brenon Araujo
+tags: [ia, agentic, loop-engineering, hermes, llm, minimax, glm, ci-cd, agentes-autonomos]
+cover: /images/blog/agentic-loop-engineering-cover.svg
+coverFallback: /images/blog/agentic-loop-engineering-cover.svg
+---
+
+# Loop Engineering Agentico — Como Agentes de IA Estão Reescrevendo a Entrega de Software
+
+O desenvolvimento de software está passando por uma mudança mais profunda do que a transição de waterfall para ágil, ou de on-premise para nuvem. Agentes de IA não são mais apenas autocompletar com esteroides — estão se tornando trabalhadores autônomos que planejam, codificam, testam, deployam e aprendem em loops contínuos. A questão não é mais *se* agentes vão escrever software, mas *como* os orquestramos para produzir resultados nos quais podemos confiar.
+
+Este artigo é um relato de campo da linha de frente. Cobrimos as principais técnicas de desenvolvimento agentic — **SDD**, **SPDD**, **BMAD**, **arquitetura de harness** e **loop engineering** — explicamos como elas se diferenciam, e mostramos como construímos um harness funcional usando **Hermes Agent**, seu plugin nativo de **Kanban** e integração com **GitHub**. Também falamos sobre a economia de rodar loops de agentes que consomem muitos tokens em modelos como **MiniMax M3** e **GLM 5.2** — que custam uma fração dos modelos frontier enquanto entregam resultados de nível produção. Por fim, compartilhamos o que funcionou, o que quebrou, e os pitfalls que encontramos no caminho enquanto entregávamos projetos reais como **oficina.brenon.cloud** e **ai.brenon.cloud**.
+
+---
+
+## O panorama: cinco técnicas, um objetivo
+
+Antes de mergulhar na implementação, vamos mapear o território. Cinco abordagens dominam o desenvolvimento de software agentic hoje. Elas não são mutuamente excludentes — na prática, os melhores harnesses pegam emprestado de todas elas.
+
+### 1. SDD — Spec-Driven Development
+
+**SDD** (Spec-Driven Development) é a abordagem mais simples e fundamental: você escreve uma especificação detalhada antes de qualquer código ser escrito, e o agente implementa exatamente o que a spec diz. A spec é o contrato. O agente é o construtor.
+
+A ideia central é que ambiguidade é a inimiga da codificação autônoma. Um desenvolvedor humano pode fazer perguntas esclarecedoras quando uma spec é vaga. Um agente de IA não pode — ou pelo menos, não deveria precisar. Quanto mais precisa a especificação, mais próxima a output fica do que você pretendia.
+
+SDD funciona bem para tarefas delimitadas: um endpoint de API, um componente React, uma CLI. Enfrenta dificuldades quando o espaço do problema é grande ou mal definido, porque a própria spec se torna o gargalo — você gasta mais tempo escrevendo specs do que código.
+
+**Características principais:**
+
+- Agente único, tarefa única
+- Spec escrita por humano, consumida por agente
+- Fluxo linear: Spec → Código → Teste
+- Orquestração mínima necessária
+- Melhor para: bug fixes, features isoladas, tarefas bem delimitadas
+
+### 2. SPDD — Spec-Driven Product Development
+
+**SPDD** estende SDD para o ciclo de vida completo do produto. Em vez de uma única spec, você produz uma cadeia de documentos: um product brief, um PRD (Product Requirements Document), decisões de arquitetura, fluxos de UX, e breakdown de stories — tudo antes da implementação começar. Múltiplos agentes podem estar envolvidos, cada um especializado em uma fase.
+
+A filosofia é que produtos falham não porque o código está errado, mas porque o *porquê* nunca foi articulado. Ao dirigir o pensamento de produto através de specs estruturadas, os agentes têm o contexto que precisam para tomar decisões alinhadas com a visão do produto — não apenas com o ticket imediato.
+
+SPDD é mais pesado que SDD, mas produz resultados dramaticamente melhores para qualquer coisa maior que uma feature isolada. É a ponte entre "vibes coding" (promptar um agente com uma frase) e engenharia.
+
+**Características principais:**
+
+- Multi-agente, multi-fase
+- Cadeia de documentos: Brief → PRD → Arquitetura → Stories → Código
+- Agentes especializam-se por fase (PM, Arquiteto, Desenvolvedor)
+- Orquestração média
+- Melhor para: produtos novos, features de plataforma, trabalho multi-componente
+
+### 3. BMAD — Breakthrough Method for Agile AI-Driven Development
+
+**BMAD** é a mais estruturada das metodologias agentic. Com mais de 50.000 stars no GitHub, oferece 12+ personas de agentes especializados (PM, Arquiteto, Desenvolvedor, UX Designer, Analista, e mais), 34+ workflows guiados, e um sistema de inteligência adaptativa por escala que ajusta a profundidade do planejamento com base na complexidade do projeto.
+
+A principal inovação do BMAD é o **planejamento adaptativo por escala e domínio**. Um bug fix segue um caminho leve de quick-flow. Uma plataforma enterprise recebe o tratamento completo de PRD + Arquitetura + Segurança + DevOps. O framework auto-detecta qual track usar com base no tamanho e complexidade do projeto, em vez de forçar toda tarefa pelo mesmo processo pesado.
+
+As fases são:
+
+1. **Análise** — brainstorming, pesquisa, product brief, PRFAQ
+2. **Planejamento** — criação de PRD, design de UX, arquitetura
+3. **Solutioning** — arquitetura, criação de epics e stories, check de prontidão para implementação
+4. **Implementação** — sprint planning, desenvolvimento story by story, code review, retros
+
+O BMAD também introduz o "Party Mode" — trazer múltiplas personas de agentes em uma mesma sessão para colaborar e discutir, simulando uma reunião de equipe real.
+
+**Características principais:**
+
+- 12+ personas de agentes especializados
+- 34+ workflows guiados across 4 fases
+- Adaptativo por escala: tracks Quick Flow, BMad Method, Enterprise
+- Party Mode para colaboração multi-agente
+- Melhor para: times que querem uma metodologia completa, não só uma ferramenta
+
+### 4. Arquitetura de Harness
+
+Um **harness** é a camada de orquestração que conecta agentes, ferramentas e verificação em um pipeline repetível. Pense nisso como CI/CD para agentes de IA: em vez de apenas deixar um agente escrever código e torcer para o melhor, o harness define como agentes são spawnados, como o trabalho é decomposto, como tarefas são atribuídas, como resultados são verificados, e como o feedback volta para a próxima iteração.
+
+Os componentes principais de um harness são:
+
+- **Orquestrador** — a sessão pai que decompose o trabalho, gerencia a fila de tarefas, e agrega resultados
+- **Agentes trabalhadores (workers)** — sessões filhas isoladas que executam tarefas individuais com suas próprias janelas de contexto
+- **Task board** — uma fila durável que rastreia estado, dependências e atribuição
+- **Camada de verificação** — testes automatizados, code review, e quality gates que decidem se a output é aceitável
+- **Feedback loop** — resultados da verificação voltam para o planejamento do próximo ciclo
+
+Um harness sem verificação é só um script runner. A camada de verificação é o que transforma *vibes coding* em *engenharia*.
+
+### 5. Loop Engineering
+
+**Loop engineering** é o paradigma que emerge quando você combina tudo acima em um ciclo contínuo. Em vez de tratar cada execução de agente como uma tarefa one-shot, loop engineering coloca o agente em um loop de feedback:
+
+1. **Planejar** — decompor o objetivo em tarefas
+2. **Executar** — agentes implementam as tarefas
+3. **Verificar** — rodar testes, code review, checks de performance
+4. **Aprender** — capturar o que funcionou e o que falhou como skills reutilizáveis
+5. **Deployar** — publicar a output verificada através de CI/CD
+6. **Repetir** — a próxima iteração começa com o conhecimento acumulado
+
+O loop é o que faz o sistema *melhorar* com o tempo. Sem ele, toda tarefa começa do zero. Com ele, o framework de agentes fica melhor no seu codebase específico, convenções e padrões — porque ele lembra.
+
+---
+
+## Comparação em um relance
+
+![Comparação de Técnicas](/images/blog/agentic-techniques-comparison.svg)
+
+| Técnica | Spec First | Modelo de Agentes | Foco em Produto | Autonomia | Verificação |
+|---------|-----------|-------------------|-----------------|-----------|-------------|
+| **SDD** | Spec → Código | Agente único | Baixo | Trigger manual | Testes |
+| **SPDD** | Spec → Produto | Multi-agente | Médio | Workflow guiado | Testes + Review |
+| **BMAD** | PRD → Arquitetura → Código | 12+ personas | Alto | Workflow guiado | Review + Retro |
+| **Harness + Loop** | Plano → Spec → Código → Verificação | Orquestrador + workers | Ciclo de vida completo | Totalmente autônomo | Unit + E2E + Load + CI/CD |
+
+---
+
+## Construindo o harness: Hermes + Kanban + GitHub
+
+Não adotamos essas técnicas no abstrato — construímos um harness funcional em cima do **Hermes Agent** e seu plugin nativo de **Kanban**. Veja como as peças se encaixam.
+
+![Arquitetura do Harness](/images/blog/agentic-harness-architecture.svg)
+
+### O orquestrador
+
+A sessão pai do Hermes atua como orquestrador. Ela recebe um objetivo — "construir um sistema de blog com suporte a i18n" ou "criar um playground de IA com múltiplos providers de modelo" — e o decompõe em tarefas discretas. Cada tarefa tem:
+
+- Uma declaração clara de objetivo
+- Uma lista de dependências (quais tarefas precisam completar antes)
+- Um worker atribuído (ou "não atribuído" para o dispatcher reivindicar)
+
+### O Kanban board
+
+O Hermes já vem com um sistema nativo de Kanban com backend em SQLite. Não é só uma UI bonita — é uma fila de trabalho durável, multi-profile, que suporta:
+
+- **Criação de tarefas** com chaves de idempotência (então re-rodar um dispatcher não duplica tarefas)
+- **Dependências** — tarefa B espera a tarefa A completar
+- **Atribuição** — tarefas são atribuídas a profiles específicos do Hermes
+- **Bloqueio** — uma tarefa que falha N vezes é auto-bloqueada
+- **Heartbeats** — workers mandam pings periódicos ao board para o dispatcher detectar claims obsoletas
+- **Modo daemon** — o dispatcher roda dentro do gateway, reclamando tarefas obsoletas e promovendo as prontas automaticamente
+
+O CLI é direto:
+
+```bash
+# Inicializar um board
+hermes kanban init --board my-feature
+
+# Criar tarefas com dependências
+hermes kanban create --board my-feature \
+  --title "Build API layer" \
+  --idempotency-key "api-layer-v1"
+
+hermes kanban create --board my-feature \
+  --title "Build frontend" \
+  --depends-on "api-layer-v1"
+
+# Linkar, atribuir, rastrear
+hermes kanban link --board my-feature \
+  --task frontend --depends-on api-layer-v1
+hermes kanban assign --board my-feature \
+  --task frontend --profile worker-1
+```
+
+### Worker agents via delegate_task
+
+O orquestrador spawn workers usando `delegate_task` em modo batch. Cada worker é um subagente totalmente isolado:
+
+- **Contexto de conversa separado** — sem poluição da janela de contexto do pai
+- **Sessão de terminal separada** — sem conflito de diretório de trabalho
+- **Subset de ferramentas** — workers só veem as ferramentas que precisam, reduzindo overhead de tokens
+- **Execução em background** — workers rodam em paralelo, e seus resultados re-entram na conversa do pai quando terminam
+
+Um dispatch típico se parece com isso:
+
+```
+delegate_task(tasks=[
+  {goal: "Build REST API for blog posts with CRUD", context: "..."},
+  {goal: "Build Vue components for blog listing and post page", context: "..."},
+  {goal: "Set up i18n with pt-BR and en-US", context: "..."}
+])
+```
+
+Três workers, três contextos isolados, rodando em paralelo. A sessão pai continua trabalhando — quando cada worker termina, seu sumário re-entra na conversa como uma nova mensagem.
+
+### Integração com GitHub
+
+Toda output de worker flui pelo GitHub:
+
+1. **Branch** — cada tarefa ganha sua própria branch
+2. **Commit** — o worker committa com mensagens convencionais (`feat:`, `fix:`, `refactor:`)
+3. **PR** — o worker abre um pull request usando `gh pr create`
+4. **CI/CD** — GitHub Actions roda a suíte de testes (unit, e2e, smoke)
+5. **Code review** — o orquestrador ou um agente reviewer dedicado revisa o diff
+6. **Merge** — depois da aprovação, o PR mergeia e a próxima tarefa desbloqueia
+
+Isso não é teórico. Usamos o `gh` CLI diretamente das sessões de agente:
+
+```bash
+# Worker cria branch e PR
+git checkout -b feat/blog-i18n
+git add -A && git commit -m "feat: add i18n support for blog posts"
+gh pr create --title "feat: add i18n support for blog posts" \
+  --body "Implements pt-BR and en-US variants for blog content"
+```
+
+A integração com GitHub é o que torna o loop *verificável*. Um agente pode escrever código, mas CI/CD diz se funciona. O PR é o artefato. O merge é o portão.
+
+---
+
+## A economia dos modelos: MiniMax M3 e GLM 5.2
+
+Aqui está a verdade desconfortável sobre loops agentic: eles consomem muitos tokens. Uma única feature — do planejamento à implementação ao review — pode consumir 50.000 a 200.000 tokens across múltiplas turnos de agente, tool calls, e janelas de contexto. Rode isso no Claude Sonnet a $3/$15 por milhão de tokens, e uma feature custa $0.50 a $3.00. Entregue 50 features e você está olhando para $25 a $150 só em API.
+
+É aqui que modelos como **MiniMax M3** e **GLM 5.2** mudam a equação.
+
+### MiniMax M3
+
+MiniMax M3 é um modelo fundacional multimodal com **janela de contexto de 1M de tokens**, construído sobre MiniMax Sparse Attention (MSA). MSA substitui full attention por seleção de KV-blocks, cortando o compute por token em contextos longos para aproximadamente **1/20 do custo da geração anterior** em 1M de tokens.
+
+**Preço no OpenRouter:** $0.30/M input, $1.20/M output.
+
+Isso significa que uma feature de 200K tokens custa aproximadamente **$0.06** de input e **$0.24** de output — **menos de $0.30 no total**. Compare com $1.50 a $3.00 num modelo frontier, e você está olhando para uma **redução de 5–10x no custo** com qualidade comparável para tarefas de codificação agentic.
+
+M3 também ranqueia no top 5–6 across múltiplas categorias de benchmark no OpenRouter, incluindo Academia (#6), Finance (#3), Health (#5), e Legal (#18). Não é um modelo de brinquedo — é um modelo de nível produção que acontece de ser dramaticamente mais barato.
+
+### GLM 5.2
+
+GLM 5.2 é o modelo de raciocínio de larga escala da Z.ai, também com **janela de contexto de 1M de tokens**. Suporta reasoning efforts `high` e `xhigh` (mapeando para max reasoning), e é especificamente tuned para **workflows de agentes de longa duração, engenharia de software em nível de projeto, e automação complexa multi-step**.
+
+**Preço no OpenRouter:** $0.91/M input, $2.86/M output.
+
+Mais caro que M3, mas ainda **3–5x mais barato** que modelos frontier. GLM 5.2 se destaca em manter contexto de engenharia across um workflow de desenvolvimento completo — de requisitos a deployment multi-plataforma — em uma única tarefa. Isso o torna ideal para o papel de orquestrador, onde precisa manter o quadro geral enquanto workers lidam com tarefas individuais.
+
+### A estratégia combinada
+
+Usamos ambos os modelos em papéis complementares:
+
+| Papel | Modelo | Por quê |
+|-------|--------|---------|
+| **Orquestrador** | GLM 5.2 | Raciocínio de contexto longo, mantém contexto do projeto, forte planejamento |
+| **Workers** | MiniMax M3 | Mais barato por token, contexto de 1M, forte codificação e tool use |
+| **Code review** | GLM 5.2 | Profundidade de raciocínio para análise de diff e avaliação de qualidade |
+| **Tarefas auxiliares** (visão, compressão) | MiniMax M3 | Custo-efetivo para alto volume, tarefas de menor risco |
+
+O resultado: um loop agentic completo — planejamento, implementação, review e deployment — custa **menos de $1 por feature** em média. Isso é barato o suficiente para rodar múltiplas iterações, tentar abordagens alternativas, e ainda sair na frente.
+
+---
+
+## Casos de estudo: oficina.brenon.cloud e ai.brenon.cloud
+
+### oficina.brenon.cloud
+
+**Oficina** é um playground de codificação criativa — uma coleção de mini-apps, experimentos e ferramentas construída com Vue 3 + Vite + Tailwind, deployada no Netlify. Foi construído quase inteiramente através de loops agentic:
+
+1. **Planejamento** — o orquestrador decompôs o projeto em tarefas: scaffold do projeto, roteamento, biblioteca de componentes, mini-apps individuais, config de deployment
+2. **Execução paralela** — 3 workers construíram mini-apps independentes simultaneamente, cada um num contexto isolado com sua própria branch
+3. **Integração** — o orquestrador mergeou os PRs, resolveu conflitos, e rodou a suíte de testes completa
+4. **Deployment** — Netlify auto-deployou no merge para `main`
+
+O projeto inteiro — de repo vazio a site deployado — levou **uma sessão**. O orquestrador spawn workers, workers abriram PRs, CI rodou testes, e o orquestrador mergeou. Zero codificação manual além do goal statement inicial.
+
+### ai.brenon.cloud
+
+**AI** é um playground de IA que permite visitantes conversarem com múltiplos providers de LLM (OpenRouter, MiniMax, Z.ai) a partir de uma interface única. Foi construído usando o mesmo padrão de harness:
+
+- **Decomposição de tarefas**: camada de API (roteamento de modelo, gerenciamento de chaves), frontend (UI de chat, seletor de modelo, respostas streaming), deployment (config do Netlify, variáveis de ambiente)
+- **Workers paralelos**: um construiu a API, um construiu o frontend, um escreveu testes
+- **Verificação em loop**: o orquestrador rodou a suíte de testes depois de cada merge de PR, pegou um bug de streaming na primeira passada, e dispatchou uma tarefa de fix automaticamente
+- **Resultado**: um playground de chat de IA funcionando e deployado em menos de 20 minutos de wall-clock time
+
+Ambos os projetos estão no ar e servindo tráfego real. Não são demos ou provas de conceito — são deployments de produção que foram construídos por agentes de IA e verificados por CI/CD.
+
+---
+
+## Mermaid: visualizando o loop do agente
+
+O ecossistema Hermes Kanban suporta diagramas Mermaid nativamente. Aqui está o ciclo de loop engineering como um flowchart:
+
+```mermaid
+flowchart TD
+    A[Goal Definition] --> B[Task Decomposition]
+    B --> C[Kanban Board]
+    C --> D1[Worker A: Implementation]
+    C --> D2[Worker B: Implementation]
+    C --> D3[Worker C: Tests]
+    D1 --> E[PR + CI/CD]
+    D2 --> E
+    D3 --> E
+    E --> F{Tests Pass?}
+    F -->|Yes| G[Code Review]
+    F -->|No| H[Auto-fix Task]
+    H --> D1
+    G --> I{Review Approved?}
+    I -->|Yes| J[Merge + Deploy]
+    I -->|No| K[Revise Task]
+    K --> D1
+    J --> L[Learn + Save Skill]
+    L --> A
+```
+
+E aqui está a arquitetura do harness como um sequence diagram:
+
+```mermaid
+sequenceDiagram
+    participant O as Orchestrator (GLM 5.2)
+    participant K as Kanban Board
+    participant W1 as Worker A (M3)
+    participant W2 as Worker B (M3)
+    participant GH as GitHub
+    participant CI as CI/CD
+
+    O->>K: Create tasks + dependencies
+    K->>W1: Claim task (isolated context)
+    K->>W2: Claim task (isolated context)
+    W1->>GH: Create branch + commit + PR
+    W2->>GH: Create branch + commit + PR
+    GH->>CI: Trigger workflow
+    CI-->>GH: Test results
+    GH-->>O: PR status + CI results
+    O->>O: Code review (GLM 5.2)
+    O->>GH: Approve + merge
+    GH->>K: Task complete
+    K-->>O: Next ready task
+```
+
+---
+
+## Pitfalls e lições aprendidas
+
+Loop engineering é poderoso, mas não é mágica. Aqui está o que aprendemos da maneira difícil.
+
+### 1. Entregas parciais importam mais que perfeição
+
+O maior erro é esperar pela output "perfeita" do agente antes de publicar. Agentes produzem resultados melhores quando iteram sobre *feedback real* — de CI, de usuários, de produção — do que quando você tenta acertar na primeira passada. Publique entregas parciais, deixe CI/CD pegar regressões, e deixe o loop refinar. Isso é entrega contínua, agora executada de forma autônoma.
+
+### 2. CI/CD é a rede de segurança, não o agente
+
+Agentes vão cometer erros. Vão introduzir bugs, quebrar testes, e às vezes produzir código que é tecnicamente correto mas arquiteturalmente errado. **CI/CD é o que torna isso seguro.** Sem uma suíte de testes robusta — testes unitários, e2e, smoke — você está voando cego. O loop do agente sem verificação é vibes coding com passos extras.
+
+Aprendemos a tratar a suíte de testes como a especificação. Se os testes passam, o código é aceito. Se falham, o loop envia uma tarefa de fix de volta para um worker. Os testes são o contrato.
+
+### 3. Janelas de contexto não são infinitas
+
+Mesmo com janelas de contexto de 1M de tokens, agentes perdem detalhes em sessões longas. Aprendemos a:
+
+- **Manter tarefas de worker pequenas e focadas** — um worker deve fazer uma coisa bem, não cinco coisas mal
+- **Usar sessões frescas para cada tarefa maior** — poluição de contexto é real
+- **Passar contexto explicitamente** — não assumir que o worker sabe qualquer coisa sobre o projeto além do que você diz
+- **Usar skills para conhecimento reutilizável** — em vez de re-explicar convenções toda vez, salve-as como uma skill que carrega automaticamente
+
+### 4. Load e performance testing no loop
+
+Um dos desenvolvimentos mais interessantes recentes é o **load e stress testing automatizado dentro do loop do agente**. O Hermes agora consegue criar benchmarks que:
+
+- Sobe um ambiente de teste
+- Gera carga contra o serviço deployado
+- Mede tempos de resposta, throughput, e taxas de erro
+- Compara resultados contra baselines de execuções anteriores
+- Cria automaticamente uma tarefa de fix se a performance regrediu
+
+Isso estende a camada de verificação além de "funciona?" para "funciona *em escala?" — que é a diferença entre uma demo e um sistema de produção.
+
+A pirâmide de testes num loop agentic agora se parece com:
+
+1. **Testes unitários** — rápidos, isolados, rodam em todo PR
+2. **Testes E2E** — nível de integração, rodam depois do merge
+3. **Smoke tests** — deployados em staging, verificam caminhos críticos
+4. **Load tests** — estressam o serviço, medem performance
+5. **Performance benchmarks** — comparam contra runs anteriores, detectam regressões
+
+Cada camada alimenta o loop de volta. Um load test que falha cria uma tarefa. A tarefa vai para um worker. O worker conserta. CI verifica. O loop continua.
+
+### 5. O paradoxo da autonomia
+
+Quanto mais autônomo o sistema se torna, mais importantes são os portões de revisão humana. Descobrimos que loops totalmente autônomos funcionam ótimo para padrões bem entendidos (CRUD APIs, componentes de UI, suítes de teste) mas precisam de checkpoints humanos para:
+
+- Decisões de arquitetura que afetam múltiplos componentes
+- Mudanças sensíveis à segurança (auth, secrets, rede)
+- Breaking changes em APIs públicas
+- Trade-offs de performance que exigem contexto de negócio
+
+O harness suporta isso naturalmente — o orquestrador pode flaggear um PR para revisão humana em vez de auto-mergear. A chave é saber *quando* escalar.
+
+### 6. Monitoramento de custo é não-negociável
+
+Com loops que consomem muitos tokens, custos podem espiralar se você não estiver de olho. Monitoramos:
+
+- **Consumo de tokens por tarefa** — quais tarefas são caras e por quê
+- **Breakdown de custo por modelo** — razão de gasto M3 vs GLM 5.2
+- **Taxa de retry** — com que frequência tarefas falham e precisam de re-dispatch
+- **Tempo ocioso do worker** — workers que claimed tarefas mas não estão fazendo progresso
+
+O Hermes tem analytics de uso embutidos (`hermes insights`) que rastreiam essas métricas. Um harness bem tunado deveria custar menos de $1 por feature. Se custa mais, algo está errado — geralmente um worker está preso num loop, ou a decomposição de tarefas está granular demais.
+
+---
+
+## O que vem a seguir
+
+Ainda estamos no começo da jornada de loop engineering. A fronteira atual não são modelos melhores — é melhor orquestração. Os modelos já são bons o suficiente. O que separa uma demo de brinquedo de um sistema de produção é o harness ao redor deles: a decomposição de tarefas, os portões de verificação, os loops de feedback, e o acúmulo de skills.
+
+Aqui está o que estamos explorando a seguir:
+
+- **Transferência de skill cross-projeto** — quando um agente aprende um padrão num projeto, consegue aplicá-lo em outro?
+- **Orquestração multi-modelo** — modelos diferentes para tipos diferentes de tarefa (codificação, review, planejamento, testes)
+- **Resposta a incidentes autônoma** — quando produção quebra, o loop consegue detectar, diagnosticar, e consertar sem intervenção humana?
+- **Validação contínua de arquitetura** — não apenas "o código funciona?" mas "a arquitetura ainda faz sentido?"
+
+A promessa do loop engineering não é que agentes substituam engenheiros. É que agentes lidem com o trabalho mecânico — a implementação, os testes, o deployment — para que engenheiros possam focar nas partes que importam: a arquitetura, a visão de produto, e o contexto humano que nenhum modelo consegue replicar.
+
+Esse é o loop que estamos construindo. E está só começando.
+
+---
+
+## Referências e Links Úteis
+
+- **[Hermes Agent](https://hermes-agent.nousresearch.com/docs/)** — Framework de agente de IA open-source pela Nous Research. A fundação do nosso harness.
+- **[Documentação do Kanban do Hermes](https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban)** — Fila de trabalho multi-agente nativa com backend SQLite, dispatcher, e profiles de worker.
+- **[BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD)** — Breakthrough Method for Agile AI-Driven Development. 50k+ stars, 12+ personas de agentes, 34+ workflows.
+- **[Docs do BMAD Method](https://docs.bmad-method.org)** — Documentação completa incluindo tutoriais, how-to guides, e referência.
+- **[MiniMax M3 no OpenRouter](https://openrouter.ai/minimax/minimax-m3)** — Contexto de 1M, $0.30/$1.20 por milhão de tokens, multimodal.
+- **[GLM 5.2 no OpenRouter](https://openrouter.ai/z-ai/glm-5.2)** — Contexto de 1M, $0.91/$2.86 por milhão de tokens, raciocínio de longa duração.
+- **[Modelos OpenRouter](https://openrouter.ai/models)** — Compare preços, janelas de contexto, e benchmarks across todos os modelos disponíveis.
+- **[GitHub CLI (gh)](https://cli.github.com/)** — Ferramenta de linha de comando para GitHub, usada por agentes para PR creation, review, e merge.
+- **[oficina.brenon.cloud](https://oficina.brenon.cloud)** — Playground de codificação criativa construído inteiramente através de loops agentic.
+- **[ai.brenon.cloud](https://ai.brenon.cloud)** — Playground de chat de IA com suporte multi-provider, construído através de loops agentic.
+- **[brenon.cloud](https://brenon.cloud)** — O blog e portfolio da home cloud onde este artigo é publicado.

--- a/src/pages/BlogPost.vue
+++ b/src/pages/BlogPost.vue
@@ -71,7 +71,7 @@
         @error="handleCoverError"
       />
 
-      <div class="prose-blog" v-html="post.html"></div>
+      <div ref="blogContent" class="prose-blog" v-html="post.html"></div>
     </article>
 
     <div v-else class="text-center py-12">
@@ -88,15 +88,54 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch, onMounted, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useBlog } from '../composables/useBlog'
+import mermaid from 'mermaid'
 
 const route = useRoute()
 const { t } = useI18n()
 const { loadPost, loading, error, locale, formatDate } = useBlog()
 const post = ref(null)
+const blogContent = ref(null)
+
+mermaid.initialize({
+  startOnLoad: false,
+  theme: 'dark',
+  themeVariables: {
+    darkMode: true,
+    primaryColor: '#3B82F6',
+    primaryTextColor: '#FFFFFF',
+    primaryBorderColor: '#1F2937',
+    lineColor: '#6B7280',
+    secondaryColor: '#1F2937',
+    secondaryTextColor: '#FFFFFF',
+    tertiaryColor: '#374151',
+    tertiaryTextColor: '#FFFFFF',
+    background: '#111827',
+    mainBkg: '#1F2937',
+    secondBkg: '#374151',
+    tertiaryBkg: '#4B5563',
+    textColor: '#FFFFFF',
+    nodeTextColor: '#FFFFFF',
+    c0: '#3B82F6',
+    c1: '#10B981',
+    c2: '#F59E0B',
+    c3: '#EF4444',
+    c4: '#8B5CF6',
+    c5: '#06B6D4',
+    c6: '#84CC16',
+    c7: '#F97316'
+  },
+  flowchart: {
+    useMaxWidth: true,
+    htmlLabels: true,
+    curve: 'basis'
+  },
+  securityLevel: 'loose',
+  suppressErrorRendering: false
+})
 
 function handleCoverError(event) {
   const image = event.currentTarget
@@ -110,8 +149,37 @@ function handleCoverError(event) {
   image.style.display = 'none'
 }
 
+async function renderMermaid() {
+  if (!blogContent.value) return
+  const mermaidDivs = blogContent.value.querySelectorAll('.mermaid')
+  if (mermaidDivs.length === 0) return
+
+  for (let i = 0; i < mermaidDivs.length; i++) {
+    const el = mermaidDivs[i]
+    const code = el.textContent
+    if (!code.trim()) continue
+    try {
+      const id = `mermaid-blog-${Date.now()}-${i}-${Math.random().toString(36).substr(2, 6)}`
+      const { svg } = await mermaid.render(id, code)
+      el.innerHTML = svg
+      const svgEl = el.querySelector('svg')
+      if (svgEl) {
+        svgEl.style.display = 'block'
+        svgEl.style.background = 'transparent'
+        svgEl.style.maxWidth = '100%'
+      }
+      el.classList.add('bg-gray-800/30', 'backdrop-blur-sm', 'rounded-xl', 'p-6', 'border', 'border-gray-700/50', 'overflow-x-auto')
+    } catch (err) {
+      console.error('Mermaid render error:', err)
+      el.innerHTML = `<div class="text-red-400 p-4 text-center text-sm"><p>Diagram render error</p><p class="text-gray-500 mt-2 text-xs">${err.message}</p></div>`
+    }
+  }
+}
+
 const fetch = async (slug) => {
   post.value = await loadPost(slug)
+  await nextTick()
+  renderMermaid()
 }
 
 onMounted(() => fetch(route.params.slug))

--- a/src/services/blogService.js
+++ b/src/services/blogService.js
@@ -34,6 +34,22 @@ const defaultImageRender =
     return self.renderToken(tokens, idx, options)
   }
 
+const defaultFenceRender =
+  md.renderer.rules.fence ||
+  function (tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options)
+  }
+
+md.renderer.rules.fence = function (tokens, idx, options, env, self) {
+  const token = tokens[idx]
+  const lang = token.info.trim()
+  if (lang === 'mermaid') {
+    const code = token.content
+    return `<div class="mermaid">${code}</div>`
+  }
+  return defaultFenceRender(tokens, idx, options, env, self)
+}
+
 md.renderer.rules.image = function (tokens, idx, options, env, self) {
   const src = tokens[idx].attrGet('src') || ''
   tokens[idx].attrSet('loading', 'lazy')


### PR DESCRIPTION
## Summary

New blog post in **English and Portuguese** covering the main agentic software development techniques and how we use them in practice at brenon.cloud.

### What's in the post

- **SDD** (Spec-Driven Development) — spec-first, single agent
- **SPDD** (Spec-Driven Product Development) — multi-agent, multi-phase product lifecycle
- **BMAD** — Breakthrough Method for Agile AI-Driven Development (12+ personas, 34+ workflows)
- **Harness Architecture** — orchestrator + workers + task board + verification layer
- **Loop Engineering** — continuous Plan → Execute → Verify → Learn → Deploy cycle

### Implementation details

- **Hermes Agent** + native **Kanban** plugin + **GitHub** integration as the harness
-  batch mode for parallel worker agents
- usage: hermes kanban [-h] [--board <slug>]
                     {init,boards,create,swarm,list,ls,show,assign,reclaim,reassign,diagnostics,diag,link,unlink,claim,comment,complete,edit,block,schedule,unblock,promote,archive,tail,dispatch,daemon,watch,stats,notify-subscribe,notify-list,notify-unsubscribe,log,runs,heartbeat,assignees,context,specify,decompose,gc}
                     ...

Durable SQLite-backed task board shared across Hermes profiles. Tasks are
claimed atomically, can depend on other tasks, and are executed by a named
profile in an isolated workspace. See https://hermes-
agent.nousresearch.com/docs/user-guide/features/kanban or docs/hermes-
kanban-v1-spec.pdf for the full design.

positional arguments:
  {init,boards,create,swarm,list,ls,show,assign,reclaim,reassign,diagnostics,diag,link,unlink,claim,comment,complete,edit,block,schedule,unblock,promote,archive,tail,dispatch,daemon,watch,stats,notify-subscribe,notify-list,notify-unsubscribe,log,runs,heartbeat,assignees,context,specify,decompose,gc}
    init                Create kanban.db if missing (idempotent)
    boards              Manage kanban boards (one board per project /
                        workstream)
    create              Create a new task
    swarm               Create a Kanban Swarm v1 graph (parallel workers →
                        verifier → synthesizer)
    list (ls)           List tasks
    show                Show a task with comments + events
    assign              Assign or reassign a task
    reclaim             Release an active worker claim on a running task
    reassign            Reassign a task to a different profile, optionally
                        reclaiming first
    diagnostics (diag)  List active diagnostics on the current board
    link                Add a parent->child dependency
    unlink              Remove a parent->child dependency
    claim               Atomically claim a ready task (prints resolved
                        workspace path)
    comment             Append a comment
    complete            Mark one or more tasks done
    edit                Edit recovery fields on an already-completed task
    block               Mark one or more tasks blocked
    schedule            Park one or more tasks in Scheduled (waiting on time,
                        not human input)
    unblock             Return one or more blocked/scheduled tasks to ready
    promote             Manually move one or more todo/blocked tasks to ready
                        (recovery path)
    archive             Archive one or more tasks
    tail                Follow a task's event stream
    dispatch            One dispatcher pass: reclaim stale, promote ready,
                        spawn workers
    daemon              DEPRECATED — dispatcher now runs in the gateway. Use
                        `hermes gateway start`.
    watch               Live-stream task_events to the terminal (Ctrl+C to
                        exit)
    stats               Per-status + per-assignee counts + oldest-ready age
    notify-subscribe    Subscribe a gateway source to a task's terminal events
                        (used by /kanban subscribe in the gateway adapter)
    notify-list         List notification subscriptions (optionally for a
                        single task)
    notify-unsubscribe  Remove a gateway subscription from a task
    log                 Print the worker log for a task (from <kanban-
                        root>/kanban/logs/)
    runs                Show attempt history for a task (one row per run:
                        profile, outcome, elapsed, summary)
    heartbeat           Emit a heartbeat event for a running task (worker
                        liveness signal)
    assignees           List known profiles + per-profile task counts (union
                        of ~/.hermes/profiles/ and current assignees on the
                        board)
    context             Print the full context a worker sees for a task (title
                        + body + parent results + comments).
    specify             Flesh out a triage-column task into a concrete spec
                        (title + body) and promote it to todo. Uses the
                        auxiliary LLM configured under
                        auxiliary.triage_specifier.
    decompose           Decompose a triage-column task into a graph of child
                        tasks routed to specialist profiles by description.
                        Falls back to specify-style single-task promotion when
                        the task doesn't benefit from fan-out. Uses
                        auxiliary.kanban_decomposer.
    gc                  Garbage-collect archived-task workspaces, old events,
                        and old logs

options:
  -h, --help            show this help message and exit
  --board <slug>        Board slug to operate on. Defaults to the current
                        board (set via `hermes kanban boards switch <slug>` or
                        the HERMES_KANBAN_BOARD env var). Use `hermes kanban
                        boards list` to see all boards. CLI for task decomposition, dependencies, and assignment
- Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  discussion:    Work with GitHub Discussions (preview)
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories
  skill:         Install and manage agent skills (preview)

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands
  telemetry:     Information about telemetry in gh

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` CLI for branch → commit → PR → CI/CD → review → merge

### Model economics

| Model | Input | Output | Context | Role |
|-------|-------|--------|---------|------|
| MiniMax M3 | $0.30/M | $1.20/M | 1M | Workers |
| GLM 5.2 | $0.91/M | $2.86/M | 1M | Orchestrator |

Combined cost: **under $1 per feature** vs $3+ on frontier models.

### Case studies

- **oficina.brenon.cloud** — creative coding playground, built entirely via agentic loops
- **ai.brenon.cloud** — AI chat playground with multi-provider support

### Visuals

- Cover SVG with loop diagram (SPEC → EXEC → TEST → LEARN → DEPLOY → PLAN)
- Harness architecture diagram (Orchestrator → Kanban → Workers → GitHub → Testing → Feedback Loop)
- Comparison table diagram (SDD vs SPDD vs BMAD vs Harness+Loop)
- Mermaid flowchart and sequence diagram inline in the post

### Pitfalls covered

- Partial deliverables > perfection
- CI/CD as the safety net
- Context window management
- Load and stress testing in the loop
- The autonomy paradox (when to escalate to humans)
- Cost monitoring

### Files added

```
src/content/blog/agentic-loop-engineering.en.md   (English, ~25KB)
src/content/blog/agentic-loop-engineering.pt.md   (Portuguese, ~27KB)
public/images/blog/agentic-loop-engineering-cover.svg
public/images/blog/agentic-harness-architecture.svg
public/images/blog/agentic-techniques-comparison.svg
```

## Test Plan

- [ ] Blog post renders correctly at `/blog/agentic-loop-engineering`
- [ ] Language switch between EN and PT works
- [ ] SVG cover and diagrams display properly
- [ ] Mermaid diagrams render (flowchart + sequence diagram)
- [ ] Tags and metadata appear in blog listing
- [ ] Reading time estimate is reasonable